### PR TITLE
fix(auth): serialize claude spawns during OAuth refresh window

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-slim
 
 # Install git and Claude CLI
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@latest
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,34 @@
 FROM node:22-slim
 
-# Install git and Claude CLI
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+# Install git + gh CLI + Claude CLI.
+# gh is used by subprocesses spawned through this proxy (claude --print, etc.)
+# that need to commit + push as the user authenticated on the host. Config
+# and credential state are mounted in at runtime (/home/node/.config/gh and
+# /home/node/.gitconfig) so the container never ships credentials itself.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates curl gnupg \
+ && mkdir -p /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && apt-get purge -y --auto-remove gnupg \
+ && rm -rf /var/lib/apt/lists/*
 RUN npm install -g @anthropic-ai/claude-code@latest
+
+# System-wide git config: wire gh as the credential helper for HTTPS GitHub
+# pushes. Keeping it in /etc/gitconfig means the user's mounted ~/.gitconfig
+# only needs user.name + user.email; credential handling works out of the
+# box. Safe-directory for /opt/repos so git doesn't balk at mounted paths
+# owned by a different uid on the host.
+RUN git config --system credential.https://github.com.helper "" \
+ && git config --system --add credential.https://github.com.helper "!gh auth git-credential" \
+ && git config --system credential.https://gist.github.com.helper "" \
+ && git config --system --add credential.https://gist.github.com.helper "!gh auth git-credential" \
+ && git config --system --add safe.directory '*'
 
 WORKDIR /app
 

--- a/src/auth/proactive-refresh.ts
+++ b/src/auth/proactive-refresh.ts
@@ -1,0 +1,94 @@
+/**
+ * Proactive OAuth refresh (defense in depth).
+ *
+ * Every REFRESH_CHECK_INTERVAL_MS, peek at the Claude credentials file. If
+ * the access_token is due to expire within REFRESH_WHEN_WITHIN_MS, fire a
+ * single lightweight `claude --print` through the token gate so the CLI
+ * drives a fresh refresh while the proxy is otherwise idle. This shrinks
+ * the window where a bursty Discord workload could race on the refresh.
+ *
+ * - Uses `runClaudeCommand` so the call is already gated.
+ * - Idempotent start/stop so callers can guard against double-starts.
+ * - Explicitly NOT started in unit tests; only `startServer` kicks it off.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { log, logError } from "../logger.js";
+import { runClaudeCommand } from "../claude-cli.inspect.js";
+
+const REFRESH_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const REFRESH_WHEN_WITHIN_MS = 2 * 60 * 60 * 1000; // 2 hours
+const PROACTIVE_CALL_TIMEOUT_MS = 30_000;
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    expiresAt?: number;
+  };
+}
+
+function defaultCredentialsPath(): string {
+  return path.join(process.env.HOME || "/tmp", ".claude", ".credentials.json");
+}
+
+function readExpiresAt(credentialsPath: string): number | null {
+  try {
+    const raw = fs.readFileSync(credentialsPath, "utf8");
+    const parsed = JSON.parse(raw) as ClaudeCredentials;
+    const expiresAt = parsed?.claudeAiOauth?.expiresAt;
+    return typeof expiresAt === "number" && Number.isFinite(expiresAt)
+      ? expiresAt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+export async function runProactiveRefreshTick(
+  credentialsPath: string = defaultCredentialsPath(),
+  now: () => number = Date.now,
+): Promise<void> {
+  const expiresAt = readExpiresAt(credentialsPath);
+  if (expiresAt === null) return;
+  const msUntilExpiry = expiresAt - now();
+  if (msUntilExpiry > REFRESH_WHEN_WITHIN_MS) return;
+
+  try {
+    const result = await runClaudeCommand(
+      ["--print", "--model", "haiku", "--output-format", "json", "ok"],
+      PROACTIVE_CALL_TIMEOUT_MS,
+    );
+    log("auth.proactive_refresh", {
+      reason: "near_expiry",
+      msUntilExpiry,
+      exitCode: result.code,
+      timedOut: result.timedOut,
+    });
+  } catch (err) {
+    logError("auth.proactive_refresh", err, {
+      reason: "spawn_failed",
+      msUntilExpiry,
+    });
+  }
+}
+
+export function startProactiveRefresh(): void {
+  if (timer) return;
+  timer = setInterval(() => {
+    runProactiveRefreshTick().catch((err) => {
+      logError("auth.proactive_refresh", err, { reason: "tick_failed" });
+    });
+  }, REFRESH_CHECK_INTERVAL_MS);
+  // Don't keep the Node event loop alive solely for this interval.
+  if (typeof timer.unref === "function") {
+    timer.unref();
+  }
+}
+
+export function stopProactiveRefresh(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/src/auth/token-gate.test.ts
+++ b/src/auth/token-gate.test.ts
@@ -17,7 +17,7 @@ function makeTempCredsPath(suffix: string): string {
 
 test("TokenGate: fast-paths (runs concurrently) outside refresh window", async () => {
   const credsPath = makeTempCredsPath("outside");
-  // expiresAt 1h in the future; window is [-10min, +2min], so we are WAY
+  // expiresAt 1h in the future; window is [-30min, +5min], so we are WAY
   // outside it and the gate should not serialize.
   const now = 1_000_000_000_000;
   writeCreds(credsPath, now + 60 * 60 * 1000);
@@ -64,7 +64,7 @@ test("TokenGate: fast-paths (runs concurrently) outside refresh window", async (
 test("TokenGate: serializes concurrent calls inside refresh window", async () => {
   const credsPath = makeTempCredsPath("inside");
   // Put `now` 2 minutes BEFORE expiresAt, which is inside the default
-  // [expiresAt - 10min, expiresAt + 2min] refresh window.
+  // [expiresAt - 30min, expiresAt + 5min] refresh window.
   const now = 1_000_000_000_000;
   writeCreds(credsPath, now + 2 * 60 * 1000);
 

--- a/src/auth/token-gate.test.ts
+++ b/src/auth/token-gate.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { TokenGate } from "./token-gate.js";
+
+function writeCreds(filePath: string, expiresAt: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify({ claudeAiOauth: { expiresAt } }));
+}
+
+function makeTempCredsPath(suffix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `token-gate-${suffix}-`));
+  return path.join(dir, ".credentials.json");
+}
+
+test("TokenGate: fast-paths (runs concurrently) outside refresh window", async () => {
+  const credsPath = makeTempCredsPath("outside");
+  // expiresAt 1h in the future; window is [-10min, +2min], so we are WAY
+  // outside it and the gate should not serialize.
+  const now = 1_000_000_000_000;
+  writeCreds(credsPath, now + 60 * 60 * 1000);
+
+  const gate = new TokenGate({
+    credentialsPath: credsPath,
+    now: () => now,
+  });
+  assert.equal(gate.isInRefreshWindow(), false);
+
+  const started: number[] = [];
+  const finished: number[] = [];
+  const slow = async (id: number): Promise<number> => {
+    started.push(id);
+    await new Promise((r) => setTimeout(r, 20));
+    finished.push(id);
+    return id;
+  };
+
+  const results = await Promise.all([
+    gate.runGated(() => slow(1)),
+    gate.runGated(() => slow(2)),
+    gate.runGated(() => slow(3)),
+  ]);
+
+  assert.deepEqual(results.sort(), [1, 2, 3]);
+  // All three should have started before any finished (parallel, not serial).
+  assert.equal(started.length, 3);
+  assert.ok(
+    started[0] !== undefined &&
+      started[1] !== undefined &&
+      started[2] !== undefined,
+  );
+  // We can't assert exact ordering of `finished` vs `started`, but we can
+  // assert that all three entered the `slow` body before the first finished
+  // — which is only possible if they ran concurrently.
+  assert.equal(
+    started.length,
+    3,
+    "all three concurrent calls entered the critical section",
+  );
+});
+
+test("TokenGate: serializes concurrent calls inside refresh window", async () => {
+  const credsPath = makeTempCredsPath("inside");
+  // Put `now` 2 minutes BEFORE expiresAt, which is inside the default
+  // [expiresAt - 10min, expiresAt + 2min] refresh window.
+  const now = 1_000_000_000_000;
+  writeCreds(credsPath, now + 2 * 60 * 1000);
+
+  const gate = new TokenGate({
+    credentialsPath: credsPath,
+    now: () => now,
+  });
+  assert.equal(gate.isInRefreshWindow(), true);
+
+  const events: Array<{ id: number; kind: "enter" | "exit" }> = [];
+  const slow = async (id: number): Promise<void> => {
+    events.push({ id, kind: "enter" });
+    await new Promise((r) => setTimeout(r, 15));
+    events.push({ id, kind: "exit" });
+  };
+
+  await Promise.all([
+    gate.runGated(() => slow(1)),
+    gate.runGated(() => slow(2)),
+    gate.runGated(() => slow(3)),
+  ]);
+
+  // Each id must appear as enter -> exit BEFORE the next id's enter.
+  assert.deepEqual(events, [
+    { id: 1, kind: "enter" },
+    { id: 1, kind: "exit" },
+    { id: 2, kind: "enter" },
+    { id: 2, kind: "exit" },
+    { id: 3, kind: "enter" },
+    { id: 3, kind: "exit" },
+  ]);
+});
+
+test("TokenGate: fast-paths when credentials file is missing", async () => {
+  const credsPath = path.join(
+    os.tmpdir(),
+    "token-gate-nonexistent",
+    ".credentials.json",
+  );
+  // Ensure it really doesn't exist.
+  try {
+    fs.unlinkSync(credsPath);
+  } catch {
+    /* noop */
+  }
+  const gate = new TokenGate({ credentialsPath: credsPath });
+  assert.equal(gate.isInRefreshWindow(), false);
+
+  const v = await gate.runGated(async () => 42);
+  assert.equal(v, 42);
+});
+
+test("TokenGate: fast-paths on malformed credentials file", async () => {
+  const credsPath = makeTempCredsPath("malformed");
+  fs.writeFileSync(credsPath, "not json at all");
+  const gate = new TokenGate({ credentialsPath: credsPath });
+  assert.equal(gate.isInRefreshWindow(), false);
+
+  const v = await gate.runGated(async () => "ok");
+  assert.equal(v, "ok");
+});
+
+test("TokenGate: releases the mutex even when fn throws", async () => {
+  const credsPath = makeTempCredsPath("throws");
+  const now = 1_000_000_000_000;
+  writeCreds(credsPath, now + 60 * 1000); // inside window
+
+  const gate = new TokenGate({
+    credentialsPath: credsPath,
+    now: () => now,
+  });
+
+  await assert.rejects(
+    gate.runGated(async () => {
+      throw new Error("boom");
+    }),
+    /boom/,
+  );
+
+  // Next call should proceed (mutex was released).
+  const v = await gate.runGated(async () => "after");
+  assert.equal(v, "after");
+});

--- a/src/auth/token-gate.ts
+++ b/src/auth/token-gate.ts
@@ -26,8 +26,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const REFRESH_LEAD_MS = 10 * 60 * 1000; // 10 minutes before expiry
-const REFRESH_TAIL_MS = 2 * 60 * 1000; // 2 minutes after expiry (grace)
+const REFRESH_LEAD_MS = 30 * 60 * 1000; // 30 minutes before expiry
+const REFRESH_TAIL_MS = 5 * 60 * 1000; // 5 minutes after expiry (grace)
 
 interface ClaudeCredentials {
   claudeAiOauth?: {

--- a/src/auth/token-gate.ts
+++ b/src/auth/token-gate.ts
@@ -16,7 +16,7 @@
  * Design
  * ------
  * - Exposes `runGated(fn)` that runs `fn()` through a promise-chained mutex
- *   ONLY when `now` falls inside `[expiresAt - 10min, expiresAt + 2min]`.
+ *   ONLY when `now` falls inside `[expiresAt - 30min, expiresAt + 5min]`.
  * - Outside that window we take the fast path (no serialization overhead).
  * - Credentials file is re-read on every call so refreshes performed by the
  *   CLI are visible immediately.

--- a/src/auth/token-gate.ts
+++ b/src/auth/token-gate.ts
@@ -1,0 +1,119 @@
+/**
+ * Token Gate: serialize `claude` CLI spawns around the OAuth refresh window.
+ *
+ * Background
+ * ----------
+ * The Claude CLI's OAuth refresh_token is rotated on every refresh: as soon as
+ * a new pair is issued, the previous refresh_token becomes invalid. When
+ * several `claude` subprocesses start concurrently and the access_token is
+ * close to its TTL, each child may try to refresh independently. The first
+ * POST wins; the others send a now-invalidated refresh_token and either
+ * overwrite `.credentials.json` with a stale response, or the access_token
+ * they just received gets superseded by the winner's write. The net result is
+ * a "zombie" credential file that looks valid locally (fresh `expiresAt`) but
+ * is already revoked server-side.
+ *
+ * Design
+ * ------
+ * - Exposes `runGated(fn)` that runs `fn()` through a promise-chained mutex
+ *   ONLY when `now` falls inside `[expiresAt - 10min, expiresAt + 2min]`.
+ * - Outside that window we take the fast path (no serialization overhead).
+ * - Credentials file is re-read on every call so refreshes performed by the
+ *   CLI are visible immediately.
+ * - Missing / malformed credentials file → fast path (fail-open to avoid
+ *   deadlocking the proxy if the file is briefly absent).
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const REFRESH_LEAD_MS = 10 * 60 * 1000; // 10 minutes before expiry
+const REFRESH_TAIL_MS = 2 * 60 * 1000; // 2 minutes after expiry (grace)
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    expiresAt?: number;
+  };
+}
+
+export interface TokenGateOptions {
+  credentialsPath?: string;
+  leadMs?: number;
+  tailMs?: number;
+  now?: () => number;
+}
+
+export class TokenGate {
+  private mutex: Promise<void> = Promise.resolve();
+  private readonly credentialsPath: string;
+  private readonly leadMs: number;
+  private readonly tailMs: number;
+  private readonly now: () => number;
+
+  constructor(options: TokenGateOptions = {}) {
+    this.credentialsPath =
+      options.credentialsPath ??
+      path.join(process.env.HOME || "/tmp", ".claude", ".credentials.json");
+    this.leadMs = options.leadMs ?? REFRESH_LEAD_MS;
+    this.tailMs = options.tailMs ?? REFRESH_TAIL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Read the OAuth expiresAt timestamp from the credentials file.
+   * Returns `null` if the file is missing, unreadable, or malformed.
+   */
+  private readExpiresAt(): number | null {
+    try {
+      const raw = fs.readFileSync(this.credentialsPath, "utf8");
+      const parsed = JSON.parse(raw) as ClaudeCredentials;
+      const expiresAt = parsed?.claudeAiOauth?.expiresAt;
+      return typeof expiresAt === "number" && Number.isFinite(expiresAt)
+        ? expiresAt
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Whether `now` falls inside the refresh window. Exposed for tests.
+   */
+  isInRefreshWindow(): boolean {
+    const expiresAt = this.readExpiresAt();
+    if (expiresAt === null) return false;
+    const now = this.now();
+    return now >= expiresAt - this.leadMs && now <= expiresAt + this.tailMs;
+  }
+
+  /**
+   * Run `fn` with token-refresh serialization applied only when necessary.
+   *
+   * Inside the refresh window: queue behind the previous gated call via a
+   * promise-chained mutex so only one `claude` subprocess can drive a
+   * refresh at a time. The mutex is held for the ENTIRE lifetime of `fn`
+   * (including any streaming subprocess) so a refresh that starts at spawn
+   * time can finish before the next subprocess begins.
+   *
+   * Outside the window: fast-path — invoke `fn` directly.
+   */
+  async runGated<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.isInRefreshWindow()) {
+      return fn();
+    }
+
+    const prev = this.mutex;
+    let release!: () => void;
+    this.mutex = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    try {
+      await prev;
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+}
+
+export const tokenGate = new TokenGate();

--- a/src/claude-cli.inspect.test.ts
+++ b/src/claude-cli.inspect.test.ts
@@ -11,7 +11,9 @@ import type { ClaudeCliMessage, ClaudeCliResult } from "./types/claude-cli.js";
 
 test("parseAuthStatus parses valid auth JSON", () => {
   assert.deepEqual(
-    parseAuthStatus('{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}'),
+    parseAuthStatus(
+      '{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}',
+    ),
     {
       loggedIn: true,
       authMethod: "oauth_token",
@@ -25,7 +27,9 @@ test("parseAuthStatus returns null for invalid JSON", () => {
 });
 
 test("parseClaudeJsonOutput parses array output", () => {
-  const messages = parseClaudeJsonOutput('[{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"result":"OK","session_id":"abc","total_cost_usd":0,"usage":{"input_tokens":1,"output_tokens":1},"modelUsage":{}}]');
+  const messages = parseClaudeJsonOutput(
+    '[{"type":"result","subtype":"success","is_error":false,"duration_ms":1,"duration_api_ms":1,"num_turns":1,"result":"OK","session_id":"abc","total_cost_usd":0,"usage":{"input_tokens":1,"output_tokens":1},"modelUsage":{}}]',
+  );
   assert.equal(messages.length, 1);
   assert.equal(messages[0]?.type, "result");
 });
@@ -40,7 +44,12 @@ test("extractClaudeErrorFromMessages classifies model access failures", () => {
         model: "<synthetic>",
         type: "message",
         role: "assistant",
-        content: [{ type: "text", text: "There's an issue with the selected model (claude-sonnet-4-6). It may not exist or you may not have access to it." }],
+        content: [
+          {
+            type: "text",
+            text: "There's an issue with the selected model (claude-sonnet-4-6). It may not exist or you may not have access to it.",
+          },
+        ],
         stop_reason: "stop_sequence",
         usage: { input_tokens: 0, output_tokens: 0 },
       },
@@ -54,7 +63,8 @@ test("extractClaudeErrorFromMessages classifies model access failures", () => {
       duration_ms: 1,
       duration_api_ms: 0,
       num_turns: 1,
-      result: "There's an issue with the selected model (claude-sonnet-4-6). It may not exist or you may not have access to it.",
+      result:
+        "There's an issue with the selected model (claude-sonnet-4-6). It may not exist or you may not have access to it.",
       session_id: "session-1",
       total_cost_usd: 0,
       usage: { input_tokens: 0, output_tokens: 0 },
@@ -87,7 +97,28 @@ test("extractClaudeErrorFromResult ignores successful results", () => {
 });
 
 test("classifyClaudeError maps auth failures", () => {
-  const error = classifyClaudeError("Claude CLI is not authenticated. Run: claude auth login");
+  const error = classifyClaudeError(
+    "Claude CLI is not authenticated. Run: claude auth login",
+  );
   assert.equal(error.status, 401);
   assert.equal(error.code, "auth_required");
+});
+
+test("classifyClaudeError maps passthrough Anthropic auth payloads", () => {
+  const cases = [
+    'API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}',
+    "HTTP 401 unauthorized from api.anthropic.com",
+    "upstream status: 401",
+    '{"error":{"type":"authentication_error"}}',
+    "Invalid authentication credentials",
+  ];
+  for (const msg of cases) {
+    const error = classifyClaudeError(msg);
+    assert.equal(error.status, 401, `expected 401 for: ${msg}`);
+    assert.equal(
+      error.code,
+      "auth_required",
+      `expected auth_required for: ${msg}`,
+    );
+  }
 });

--- a/src/claude-cli.inspect.test.ts
+++ b/src/claude-cli.inspect.test.ts
@@ -6,6 +6,8 @@ import {
   extractClaudeErrorFromResult,
   parseAuthStatus,
   parseClaudeJsonOutput,
+  parseClaudeVersion,
+  supportsXHighEffort,
 } from "./claude-cli.inspect.js";
 import type { ClaudeCliMessage, ClaudeCliResult } from "./types/claude-cli.js";
 
@@ -121,4 +123,20 @@ test("classifyClaudeError maps passthrough Anthropic auth payloads", () => {
       `expected auth_required for: ${msg}`,
     );
   }
+});
+
+test("parseClaudeVersion extracts semver from Claude CLI output", () => {
+  assert.deepEqual(parseClaudeVersion("claude 2.1.112"), {
+    major: 2,
+    minor: 1,
+    patch: 112,
+  });
+  assert.equal(parseClaudeVersion("Claude Code CLI"), null);
+});
+
+test("supportsXHighEffort only enables xhigh on supported CLI versions", () => {
+  assert.equal(supportsXHighEffort("claude 2.1.111"), false);
+  assert.equal(supportsXHighEffort("claude 2.1.112"), true);
+  assert.equal(supportsXHighEffort("claude 2.2.0"), true);
+  assert.equal(supportsXHighEffort(undefined), false);
 });

--- a/src/claude-cli.inspect.ts
+++ b/src/claude-cli.inspect.ts
@@ -135,7 +135,7 @@ export function classifyClaudeError(
   }
 
   if (
-    /not authenticated|auth login|authentication|logged out|oauth|token/i.test(
+    /not authenticated|auth login|authentication|logged out|oauth|token|"authentication_error"|invalid authentication credentials|status:\s*401|http\s*401|\b401\s+unauthorized\b|\b401\s+\{/i.test(
       lower,
     )
   ) {

--- a/src/claude-cli.inspect.ts
+++ b/src/claude-cli.inspect.ts
@@ -6,6 +6,7 @@ import type {
   ClaudeCliMessage,
   ClaudeCliResult,
 } from "./types/claude-cli.js";
+import { tokenGate } from "./auth/token-gate.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10000;
 const PROBE_PROMPT = "Reply with exactly: OK";
@@ -217,43 +218,50 @@ export async function runClaudeCommand(
   args: string[],
   timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
 ): Promise<ClaudeCommandResult> {
-  return new Promise<ClaudeCommandResult>((resolve) => {
-    const proc = spawn("claude", args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: getCleanClaudeEnv(),
-    });
+  // Serialize spawns during the OAuth refresh window so concurrent `claude`
+  // invocations can't race on refresh_token rotation. Outside the window the
+  // gate fast-paths with no overhead. The gated promise resolves on child
+  // EXIT (via close/error) so the mutex is held for the full lifetime.
+  return tokenGate.runGated(
+    () =>
+      new Promise<ClaudeCommandResult>((resolve) => {
+        const proc = spawn("claude", args, {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: getCleanClaudeEnv(),
+        });
 
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
+        let stdout = "";
+        let stderr = "";
+        let timedOut = false;
 
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      try {
-        proc.kill("SIGTERM");
-      } catch {
-        // ignore
-      }
-    }, timeoutMs);
+        const timeoutId = setTimeout(() => {
+          timedOut = true;
+          try {
+            proc.kill("SIGTERM");
+          } catch {
+            // ignore
+          }
+        }, timeoutMs);
 
-    proc.stdout?.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
+        proc.stdout?.on("data", (chunk: Buffer) => {
+          stdout += chunk.toString();
+        });
 
-    proc.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
+        proc.stderr?.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString();
+        });
 
-    proc.on("error", () => {
-      clearTimeout(timeoutId);
-      resolve({ stdout, stderr, code: null, signal: null, timedOut });
-    });
+        proc.on("error", () => {
+          clearTimeout(timeoutId);
+          resolve({ stdout, stderr, code: null, signal: null, timedOut });
+        });
 
-    proc.on("close", (code, signal) => {
-      clearTimeout(timeoutId);
-      resolve({ stdout, stderr, code, signal, timedOut });
-    });
-  });
+        proc.on("close", (code, signal) => {
+          clearTimeout(timeoutId);
+          resolve({ stdout, stderr, code, signal, timedOut });
+        });
+      }),
+  );
 }
 
 export async function verifyClaude(): Promise<{

--- a/src/claude-cli.inspect.ts
+++ b/src/claude-cli.inspect.ts
@@ -7,9 +7,12 @@ import type {
   ClaudeCliResult,
 } from "./types/claude-cli.js";
 import { tokenGate } from "./auth/token-gate.js";
+import { createEscalatedStop } from "./subprocess/stop-with-escalation.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10000;
 const PROBE_PROMPT = "Reply with exactly: OK";
+const COMMAND_KILL_GRACE_MS = 5000;
+const COMMAND_FORCE_RELEASE_MS = 1000;
 const XHIGH_MIN_VERSION = { major: 2, minor: 1, patch: 112 } as const;
 
 const CLEAN_CLAUDE_ENV = (() => {
@@ -270,14 +273,32 @@ export async function runClaudeCommand(
         let stdout = "";
         let stderr = "";
         let timedOut = false;
+        let code: number | null = null;
+        let signal: NodeJS.Signals | null = null;
+        let settled = false;
+
+        const finalize = (): void => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeoutId);
+          resolve({ stdout, stderr, code, signal, timedOut });
+        };
+
+        proc.on("close", (closeCode, closeSignal) => {
+          code = closeCode;
+          signal = closeSignal;
+        });
+
+        const stopper = createEscalatedStop(
+          proc,
+          finalize,
+          COMMAND_KILL_GRACE_MS,
+          COMMAND_FORCE_RELEASE_MS,
+        );
 
         const timeoutId = setTimeout(() => {
           timedOut = true;
-          try {
-            proc.kill("SIGTERM");
-          } catch {
-            // ignore
-          }
+          stopper.requestStop();
         }, timeoutMs);
 
         proc.stdout?.on("data", (chunk: Buffer) => {
@@ -289,13 +310,7 @@ export async function runClaudeCommand(
         });
 
         proc.on("error", () => {
-          clearTimeout(timeoutId);
-          resolve({ stdout, stderr, code: null, signal: null, timedOut });
-        });
-
-        proc.on("close", (code, signal) => {
-          clearTimeout(timeoutId);
-          resolve({ stdout, stderr, code, signal, timedOut });
+          stopper.settle();
         });
       }),
   );

--- a/src/claude-cli.inspect.ts
+++ b/src/claude-cli.inspect.ts
@@ -10,6 +10,7 @@ import { tokenGate } from "./auth/token-gate.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10000;
 const PROBE_PROMPT = "Reply with exactly: OK";
+const XHIGH_MIN_VERSION = { major: 2, minor: 1, patch: 112 } as const;
 
 const CLEAN_CLAUDE_ENV = (() => {
   const env = { ...process.env };
@@ -19,6 +20,9 @@ const CLEAN_CLAUDE_ENV = (() => {
   delete env.CLAUDE_CODE_PARENT;
   return env;
 })();
+
+let cachedClaudeVersion = process.env.CLAUDE_PROXY_CLAUDE_VERSION?.trim()
+  || undefined;
 
 export interface ClaudeCommandResult {
   stdout: string;
@@ -51,6 +55,39 @@ export interface ModelProbeResult {
 
 export function getCleanClaudeEnv(): NodeJS.ProcessEnv {
   return { ...CLEAN_CLAUDE_ENV };
+}
+
+export interface ClaudeCliVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function parseClaudeVersion(
+  raw: string | undefined,
+): ClaudeCliVersion | null {
+  const match = raw?.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function supportsXHighEffort(
+  version: string | undefined = cachedClaudeVersion,
+): boolean {
+  const parsed = parseClaudeVersion(version);
+  if (!parsed) return false;
+
+  if (parsed.major !== XHIGH_MIN_VERSION.major) {
+    return parsed.major > XHIGH_MIN_VERSION.major;
+  }
+  if (parsed.minor !== XHIGH_MIN_VERSION.minor) {
+    return parsed.minor > XHIGH_MIN_VERSION.minor;
+  }
+  return parsed.patch >= XHIGH_MIN_VERSION.patch;
 }
 
 export function parseClaudeJsonOutput(raw: string): ClaudeCliMessage[] {
@@ -271,8 +308,11 @@ export async function verifyClaude(): Promise<{
 }> {
   const result = await runClaudeCommand(["--version"], 5000);
   if (result.code === 0) {
-    return { ok: true, version: result.stdout.trim() };
+    const version = result.stdout.trim();
+    cachedClaudeVersion = version || undefined;
+    return { ok: true, version };
   }
+  cachedClaudeVersion = undefined;
   return {
     ok: false,
     error:

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -30,7 +30,9 @@ export type LogEvent =
   | "server.start"
   | "admin.thinking_budget.set"
   | "admin.thinking_budget.cleared"
-  | "auth.proactive_refresh";
+  | "auth.proactive_refresh"
+  | "auth.failure"
+  | "auth.recovered";
 
 export interface LogEntry {
   ts: string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,7 +29,8 @@ export type LogEvent =
   | "server.shutdown"
   | "server.start"
   | "admin.thinking_budget.set"
-  | "admin.thinking_budget.cleared";
+  | "admin.thinking_budget.cleared"
+  | "auth.proactive_refresh";
 
 export interface LogEntry {
   ts: string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -32,7 +32,10 @@ export type LogEvent =
   | "admin.thinking_budget.cleared"
   | "auth.proactive_refresh"
   | "auth.failure"
-  | "auth.recovered";
+  | "auth.recovered"
+  | "cli.error"
+  | "pool.warmed"
+  | "pool.warm_failed";
 
 export interface LogEntry {
   ts: string;

--- a/src/model-availability.test.ts
+++ b/src/model-availability.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ModelAvailabilityManager,
+  type ModelAvailabilitySnapshot,
+} from "./model-availability.js";
+import type { ModelDefinition } from "./models.js";
+
+const definition: ModelDefinition = {
+  id: "claude-sonnet-4-6",
+  family: "sonnet",
+  alias: "sonnet",
+  timeoutMs: 1,
+  stallTimeoutMs: 1,
+};
+
+function makeManager(
+  verifyAuthCalls: Array<() => Promise<{ ok: boolean; error?: string; status?: { loggedIn: boolean } }>>,
+  exits: number[],
+): ModelAvailabilityManager {
+  let idx = 0;
+  return new ModelAvailabilityManager({
+    verifyAuth: async () => verifyAuthCalls[Math.min(idx++, verifyAuthCalls.length - 1)](),
+    probeModelAvailability: async () => ({
+      ok: true,
+      model: definition.id,
+      resolvedModel: definition.id,
+    }),
+    getModelDefinitions: () => [definition],
+    exitProcess: (code: number) => {
+      exits.push(code);
+    },
+  });
+}
+
+test("ModelAvailabilityManager cancels a scheduled self-exit after auth recovery", async () => {
+  const exits: number[] = [];
+  const manager = makeManager(
+    [
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: true, status: { loggedIn: true } }),
+    ],
+    exits,
+  );
+
+  for (let i = 0; i < 5; i++) {
+    await manager.getSnapshot(true);
+  }
+  assert.equal(manager.getConsecutiveAuthFailures(), 5);
+
+  const recovered = (await manager.getSnapshot(true)) as ModelAvailabilitySnapshot;
+  assert.equal(manager.getConsecutiveAuthFailures(), 0);
+  assert.deepEqual(recovered.available.map((model) => model.id), [definition.id]);
+
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  assert.deepEqual(exits, []);
+});
+
+test("ModelAvailabilityManager exits after sustained auth failure", async () => {
+  const exits: number[] = [];
+  const manager = makeManager(
+    [
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+      async () => ({ ok: false, error: "auth failed" }),
+    ],
+    exits,
+  );
+
+  for (let i = 0; i < 5; i++) {
+    await manager.getSnapshot(true);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  assert.deepEqual(exits, [1]);
+});

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -11,6 +11,7 @@ import {
   type ModelDefinition,
   type ModelFamily,
 } from "./models.js";
+import { log } from "./logger.js";
 
 const PROBE_TTL_MS = 10 * 60 * 1000;
 // When verifyAuth fails, normally the PROBE_TTL_MS cache would hold the
@@ -20,6 +21,14 @@ const PROBE_TTL_MS = 10 * 60 * 1000;
 // auth failure has been observed.
 const AUTH_RETRY_COOLDOWN_MS = 60 * 1000;
 const DEFAULT_FAMILY_ORDER: ModelFamily[] = ["sonnet", "opus", "haiku"];
+
+// Self-exit threshold: once this many consecutive verifyAuth failures have
+// occurred, the proxy can no longer recover without outside help (credential
+// file is zombie or the account is locked). Exit so Docker's
+// `restart: unless-stopped` kicks us back up; the CLI re-reads creds on boot
+// and the subprocess pool re-warms, which is enough to escape most stuck
+// states without manual `make restart`.
+const AUTH_SELF_EXIT_THRESHOLD = 5;
 
 export interface ModelAvailabilitySnapshot {
   checkedAt: number;
@@ -45,9 +54,19 @@ class ModelAvailabilityManager {
   private snapshot: ModelAvailabilitySnapshot | null = null;
   private refreshPromise: Promise<ModelAvailabilitySnapshot> | null = null;
   private lastAuthRetryAt = 0;
+  private consecutiveAuthFailures = 0;
 
   getCachedSnapshot(): ModelAvailabilitySnapshot | null {
     return this.snapshot;
+  }
+
+  /**
+   * Count of consecutive `refresh()` calls that came back with an auth
+   * failure. Resets to 0 on the first successful `verifyAuth`. Exposed so
+   * `/health` can fail when the credential file looks zombie.
+   */
+  getConsecutiveAuthFailures(): number {
+    return this.consecutiveAuthFailures;
   }
 
   invalidate(): void {
@@ -137,6 +156,18 @@ class ModelAvailabilityManager {
     const definitions = getModelDefinitions();
 
     if (!authResult.ok) {
+      this.consecutiveAuthFailures += 1;
+      if (this.consecutiveAuthFailures >= AUTH_SELF_EXIT_THRESHOLD) {
+        log("auth.failure", {
+          phase: "self_exit",
+          consecutiveAuthFailures: this.consecutiveAuthFailures,
+          message:
+            "verifyAuth failed consecutively; exiting so the container restarts and re-reads credentials",
+        });
+        // Let Docker's restart policy bring us back. Small delay so the log
+        // has a chance to flush before the process dies.
+        setTimeout(() => process.exit(1), 250);
+      }
       return {
         checkedAt: Date.now(),
         auth: authResult.status ?? null,
@@ -152,6 +183,8 @@ class ModelAvailabilityManager {
         })),
       };
     }
+
+    this.consecutiveAuthFailures = 0;
 
     const probes = await Promise.all(
       definitions.map(async (definition) => ({

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -1,7 +1,24 @@
-import { probeModelAvailability, verifyAuth, type ClaudeAuthStatus, type ClaudeProxyError } from "./claude-cli.inspect.js";
-import { getModelDefinitions, getModelList, resolveModelFamily, type ModelDefinition, type ModelFamily } from "./models.js";
+import {
+  probeModelAvailability,
+  verifyAuth,
+  type ClaudeAuthStatus,
+  type ClaudeProxyError,
+} from "./claude-cli.inspect.js";
+import {
+  getModelDefinitions,
+  getModelList,
+  resolveModelFamily,
+  type ModelDefinition,
+  type ModelFamily,
+} from "./models.js";
 
 const PROBE_TTL_MS = 10 * 60 * 1000;
+// When verifyAuth fails, normally the PROBE_TTL_MS cache would hold the
+// "no models available" state for 10 minutes even though a fresh token
+// refresh might succeed. To avoid sticking requests behind that cache, we
+// force a refresh attempt at most once every AUTH_RETRY_COOLDOWN_MS when an
+// auth failure has been observed.
+const AUTH_RETRY_COOLDOWN_MS = 60 * 1000;
 const DEFAULT_FAMILY_ORDER: ModelFamily[] = ["sonnet", "opus", "haiku"];
 
 export interface ModelAvailabilitySnapshot {
@@ -14,7 +31,9 @@ export interface ModelAvailabilitySnapshot {
   }>;
 }
 
-function pickDefaultModel(available: ModelDefinition[]): ModelDefinition | null {
+function pickDefaultModel(
+  available: ModelDefinition[],
+): ModelDefinition | null {
   for (const family of DEFAULT_FAMILY_ORDER) {
     const match = available.find((definition) => definition.family === family);
     if (match) return match;
@@ -25,6 +44,7 @@ function pickDefaultModel(available: ModelDefinition[]): ModelDefinition | null 
 class ModelAvailabilityManager {
   private snapshot: ModelAvailabilitySnapshot | null = null;
   private refreshPromise: Promise<ModelAvailabilitySnapshot> | null = null;
+  private lastAuthRetryAt = 0;
 
   getCachedSnapshot(): ModelAvailabilitySnapshot | null {
     return this.snapshot;
@@ -34,9 +54,27 @@ class ModelAvailabilityManager {
     this.snapshot = null;
   }
 
+  /**
+   * When the last snapshot shows the CLI as unauthenticated, the generic
+   * PROBE_TTL_MS (10 min) cache keeps returning "no models" even after a
+   * successful token refresh. Bypass the cache at most once per
+   * AUTH_RETRY_COOLDOWN_MS so a healed token is picked up quickly without
+   * hammering verifyAuth on every request.
+   */
+  private shouldForceAuthRetry(): boolean {
+    if (!this.snapshot) return false;
+    if (this.snapshot.auth?.loggedIn) return false;
+    return Date.now() - this.lastAuthRetryAt >= AUTH_RETRY_COOLDOWN_MS;
+  }
+
   async getSnapshot(force = false): Promise<ModelAvailabilitySnapshot> {
-    const isFresh = this.snapshot && (Date.now() - this.snapshot.checkedAt) < PROBE_TTL_MS;
-    if (!force && isFresh) {
+    const isFresh =
+      this.snapshot && Date.now() - this.snapshot.checkedAt < PROBE_TTL_MS;
+    const authRetry = this.shouldForceAuthRetry();
+    if (authRetry) {
+      this.lastAuthRetryAt = Date.now();
+    }
+    if (!force && !authRetry && isFresh) {
       return this.snapshot!;
     }
 
@@ -53,12 +91,16 @@ class ModelAvailabilityManager {
     }
   }
 
-  async getPublicModelList(): Promise<Array<{ id: string; object: string; owned_by: string; created: number }>> {
+  async getPublicModelList(): Promise<
+    Array<{ id: string; object: string; owned_by: string; created: number }>
+  > {
     const snapshot = await this.getSnapshot();
     return getModelList(snapshot.available);
   }
 
-  async resolveRequestedModel(requestedModel?: string): Promise<ModelDefinition | null> {
+  async resolveRequestedModel(
+    requestedModel?: string,
+  ): Promise<ModelDefinition | null> {
     const snapshot = await this.getSnapshot();
     if (snapshot.available.length === 0) {
       return null;
@@ -74,7 +116,9 @@ class ModelAvailabilityManager {
         ? requestedModel.slice("claude-code-cli/".length)
         : requestedModel;
 
-    const exact = snapshot.available.find((definition) => definition.id === normalized);
+    const exact = snapshot.available.find(
+      (definition) => definition.id === normalized,
+    );
     if (exact) return exact;
 
     const family = resolveModelFamily(normalized);
@@ -82,7 +126,10 @@ class ModelAvailabilityManager {
       return null;
     }
 
-    return snapshot.available.find((definition) => definition.family === family) ?? null;
+    return (
+      snapshot.available.find((definition) => definition.family === family) ??
+      null
+    );
   }
 
   private async refresh(): Promise<ModelAvailabilitySnapshot> {
@@ -106,10 +153,12 @@ class ModelAvailabilityManager {
       };
     }
 
-    const probes = await Promise.all(definitions.map(async (definition) => ({
-      definition,
-      result: await probeModelAvailability(definition.id),
-    })));
+    const probes = await Promise.all(
+      definitions.map(async (definition) => ({
+        definition,
+        result: await probeModelAvailability(definition.id),
+      })),
+    );
 
     const available: ModelDefinition[] = [];
     const unavailable: ModelAvailabilitySnapshot["unavailable"] = [];

--- a/src/model-availability.ts
+++ b/src/model-availability.ts
@@ -29,6 +29,7 @@ const DEFAULT_FAMILY_ORDER: ModelFamily[] = ["sonnet", "opus", "haiku"];
 // and the subprocess pool re-warms, which is enough to escape most stuck
 // states without manual `make restart`.
 const AUTH_SELF_EXIT_THRESHOLD = 5;
+const AUTH_SELF_EXIT_DELAY_MS = 250;
 
 export interface ModelAvailabilitySnapshot {
   checkedAt: number;
@@ -50,11 +51,30 @@ function pickDefaultModel(
   return available[0] ?? null;
 }
 
-class ModelAvailabilityManager {
+interface ModelAvailabilityDeps {
+  verifyAuth: typeof verifyAuth;
+  probeModelAvailability: typeof probeModelAvailability;
+  getModelDefinitions: typeof getModelDefinitions;
+  exitProcess: (code: number) => void;
+}
+
+const defaultDeps: ModelAvailabilityDeps = {
+  verifyAuth,
+  probeModelAvailability,
+  getModelDefinitions,
+  exitProcess: (code) => {
+    process.exit(code);
+  },
+};
+
+export class ModelAvailabilityManager {
   private snapshot: ModelAvailabilitySnapshot | null = null;
   private refreshPromise: Promise<ModelAvailabilitySnapshot> | null = null;
   private lastAuthRetryAt = 0;
   private consecutiveAuthFailures = 0;
+  private selfExitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly deps: ModelAvailabilityDeps = defaultDeps) {}
 
   getCachedSnapshot(): ModelAvailabilitySnapshot | null {
     return this.snapshot;
@@ -71,6 +91,23 @@ class ModelAvailabilityManager {
 
   invalidate(): void {
     this.snapshot = null;
+  }
+
+  private scheduleSelfExit(): void {
+    if (this.selfExitTimer) return;
+    this.selfExitTimer = setTimeout(() => {
+      this.selfExitTimer = null;
+      this.deps.exitProcess(1);
+    }, AUTH_SELF_EXIT_DELAY_MS);
+    if (typeof this.selfExitTimer.unref === "function") {
+      this.selfExitTimer.unref();
+    }
+  }
+
+  private clearSelfExit(): void {
+    if (!this.selfExitTimer) return;
+    clearTimeout(this.selfExitTimer);
+    this.selfExitTimer = null;
   }
 
   /**
@@ -152,8 +189,8 @@ class ModelAvailabilityManager {
   }
 
   private async refresh(): Promise<ModelAvailabilitySnapshot> {
-    const authResult = await verifyAuth();
-    const definitions = getModelDefinitions();
+    const authResult = await this.deps.verifyAuth();
+    const definitions = this.deps.getModelDefinitions();
 
     if (!authResult.ok) {
       this.consecutiveAuthFailures += 1;
@@ -164,9 +201,8 @@ class ModelAvailabilityManager {
           message:
             "verifyAuth failed consecutively; exiting so the container restarts and re-reads credentials",
         });
-        // Let Docker's restart policy bring us back. Small delay so the log
-        // has a chance to flush before the process dies.
-        setTimeout(() => process.exit(1), 250);
+        // Small delay so the log has a chance to flush before the process dies.
+        this.scheduleSelfExit();
       }
       return {
         checkedAt: Date.now(),
@@ -185,11 +221,12 @@ class ModelAvailabilityManager {
     }
 
     this.consecutiveAuthFailures = 0;
+    this.clearSelfExit();
 
     const probes = await Promise.all(
       definitions.map(async (definition) => ({
         definition,
-        result: await probeModelAvailability(definition.id),
+        result: await this.deps.probeModelAvailability(definition.id),
       })),
     );
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -27,16 +27,71 @@ export interface ModelDefinition {
  */
 const MODEL_DEFINITIONS: ModelDefinition[] = [
   // Opus — current model first (becomes canonical via CANONICAL_IDS)
-  { id: "claude-opus-4-6", family: "opus",   alias: "opus",   timeoutMs: 1800000, stallTimeoutMs: 120000 },
-  { id: "claude-opus-4",   family: "opus",   alias: "opus",   timeoutMs: 1800000, stallTimeoutMs: 120000 },
-  { id: "claude-opus-4-5", family: "opus",   alias: "opus",   timeoutMs: 1800000, stallTimeoutMs: 120000 },
+  {
+    id: "claude-opus-4-7",
+    family: "opus",
+    alias: "opus",
+    timeoutMs: 1800000,
+    stallTimeoutMs: 120000,
+  },
+  {
+    id: "claude-opus-4-6",
+    family: "opus",
+    alias: "opus",
+    timeoutMs: 1800000,
+    stallTimeoutMs: 120000,
+  },
+  {
+    id: "claude-opus-4",
+    family: "opus",
+    alias: "opus",
+    timeoutMs: 1800000,
+    stallTimeoutMs: 120000,
+  },
+  {
+    id: "claude-opus-4-5",
+    family: "opus",
+    alias: "opus",
+    timeoutMs: 1800000,
+    stallTimeoutMs: 120000,
+  },
   // Sonnet — current model first
-  { id: "claude-sonnet-4-6", family: "sonnet", alias: "sonnet", timeoutMs: 600000, stallTimeoutMs: 90000 },
-  { id: "claude-sonnet-4",   family: "sonnet", alias: "sonnet", timeoutMs: 600000, stallTimeoutMs: 90000 },
-  { id: "claude-sonnet-4-5", family: "sonnet", alias: "sonnet", timeoutMs: 600000, stallTimeoutMs: 90000 },
+  {
+    id: "claude-sonnet-4-6",
+    family: "sonnet",
+    alias: "sonnet",
+    timeoutMs: 600000,
+    stallTimeoutMs: 90000,
+  },
+  {
+    id: "claude-sonnet-4",
+    family: "sonnet",
+    alias: "sonnet",
+    timeoutMs: 600000,
+    stallTimeoutMs: 90000,
+  },
+  {
+    id: "claude-sonnet-4-5",
+    family: "sonnet",
+    alias: "sonnet",
+    timeoutMs: 600000,
+    stallTimeoutMs: 90000,
+  },
   // Haiku — current model first
-  { id: "claude-haiku-4-5", family: "haiku", alias: "haiku", timeoutMs: 120000, stallTimeoutMs: 45000 },
-  { id: "claude-haiku-4",   family: "haiku", alias: "haiku", timeoutMs: 120000, stallTimeoutMs: 45000 },
+  {
+    id: "claude-haiku-4-5",
+    family: "haiku",
+    alias: "haiku",
+    timeoutMs: 120000,
+    stallTimeoutMs: 45000,
+  },
+  {
+    id: "claude-haiku-4",
+    family: "haiku",
+    alias: "haiku",
+    timeoutMs: 120000,
+    stallTimeoutMs: 45000,
+  },
 ];
 
 // Provider prefixes that clients may prepend
@@ -69,7 +124,7 @@ for (const def of MODEL_DEFINITIONS) {
 
 // Bare aliases: "opus" -> opus, "sonnet" -> sonnet, "haiku" -> haiku
 for (const family of ["opus", "sonnet", "haiku"] as const) {
-  const def = MODEL_DEFINITIONS.find(d => d.family === family);
+  const def = MODEL_DEFINITIONS.find((d) => d.family === family);
   if (def) {
     MODEL_LOOKUP.set(family, {
       id: def.id,
@@ -127,8 +182,8 @@ export function getModelTimeout(model: string): number {
   if (entry) return entry.timeoutMs;
 
   const lower = (model || "").toLowerCase();
-  if (lower.includes("opus"))   return 1800000;
-  if (lower.includes("haiku"))  return 120000;
+  if (lower.includes("opus")) return 1800000;
+  if (lower.includes("haiku")) return 120000;
   if (lower.includes("sonnet")) return 600000;
 
   return 180000;
@@ -143,8 +198,8 @@ export function getStallTimeout(model: string): number {
   if (entry) return entry.stallTimeoutMs;
 
   const lower = (model || "").toLowerCase();
-  if (lower.includes("opus"))   return 120000;
-  if (lower.includes("haiku"))  return 45000;
+  if (lower.includes("opus")) return 120000;
+  if (lower.includes("haiku")) return 45000;
   if (lower.includes("sonnet")) return 90000;
 
   return 90000;
@@ -171,17 +226,19 @@ for (const def of MODEL_DEFINITIONS) {
 export function normalizeModelName(model: string): string {
   if (!model) return CANONICAL_IDS.sonnet!;
   const lower = model.toLowerCase();
-  if (lower.includes("opus"))   return CANONICAL_IDS.opus!;
+  if (lower.includes("opus")) return CANONICAL_IDS.opus!;
   if (lower.includes("sonnet")) return CANONICAL_IDS.sonnet!;
-  if (lower.includes("haiku"))  return CANONICAL_IDS.haiku!;
+  if (lower.includes("haiku")) return CANONICAL_IDS.haiku!;
   return model;
 }
 
 /**
  * Get the OpenAI-compatible /v1/models response data.
  */
-export function getModelList(definitions: ModelDefinition[] = MODEL_DEFINITIONS): Array<{ id: string; object: string; owned_by: string; created: number }> {
-  return definitions.map(def => ({
+export function getModelList(
+  definitions: ModelDefinition[] = MODEL_DEFINITIONS,
+): Array<{ id: string; object: string; owned_by: string; created: number }> {
+  return definitions.map((def) => ({
     id: def.id,
     object: "model" as const,
     owned_by: "anthropic",

--- a/src/server/auth-retry.test.ts
+++ b/src/server/auth-retry.test.ts
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isAuthError, withAuthRetry } from "./auth-retry.js";
+
+test("isAuthError: matches auth_required code", () => {
+  assert.equal(
+    isAuthError({
+      status: 401,
+      type: "authentication_error",
+      code: "auth_required",
+      message: "Claude CLI is not authenticated",
+    }),
+    true,
+  );
+});
+
+test("isAuthError: matches Anthropic 'Invalid authentication credentials'", () => {
+  assert.equal(
+    isAuthError({
+      status: 502,
+      type: "server_error",
+      code: "claude_cli_error",
+      message:
+        'API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}',
+    }),
+    true,
+  );
+});
+
+test("isAuthError: matches raw 'status: 401'", () => {
+  assert.equal(
+    isAuthError({
+      status: 502,
+      type: "server_error",
+      code: "claude_cli_error",
+      message: "Something bad happened (status: 401)",
+    }),
+    true,
+  );
+});
+
+test("isAuthError: returns false for unrelated errors", () => {
+  assert.equal(
+    isAuthError({
+      status: 429,
+      type: "rate_limit_error",
+      code: "rate_limited",
+      message: "Too many requests",
+    }),
+    false,
+  );
+  assert.equal(
+    isAuthError({
+      status: 400,
+      type: "invalid_request_error",
+      code: "model_unavailable",
+      message: "There's an issue with the selected model",
+    }),
+    false,
+  );
+});
+
+test("withAuthRetry: no retry when first attempt succeeds", async () => {
+  const calls: boolean[] = [];
+  let invalidated = 0;
+  const result = await withAuthRetry(
+    async (allowAuthRetry) => {
+      calls.push(allowAuthRetry);
+      return { success: true };
+    },
+    () => {
+      invalidated++;
+    },
+  );
+  assert.deepEqual(calls, [true]);
+  assert.equal(invalidated, 0);
+  assert.deepEqual(result, { success: true });
+});
+
+test("withAuthRetry: no retry when first attempt non-auth-failed", async () => {
+  const calls: boolean[] = [];
+  let invalidated = 0;
+  const result = await withAuthRetry(
+    async (allowAuthRetry) => {
+      calls.push(allowAuthRetry);
+      return { success: false };
+    },
+    () => {
+      invalidated++;
+    },
+  );
+  assert.deepEqual(calls, [true]);
+  assert.equal(invalidated, 0);
+  assert.deepEqual(result, { success: false });
+});
+
+test("withAuthRetry: invalidates cache and retries exactly once on auth failure", async () => {
+  const calls: boolean[] = [];
+  let invalidated = 0;
+  const result = await withAuthRetry(
+    async (allowAuthRetry) => {
+      calls.push(allowAuthRetry);
+      // First call: auth error. Second call: success.
+      if (calls.length === 1) {
+        return { authErrored: true, success: false };
+      }
+      return { success: true };
+    },
+    () => {
+      invalidated++;
+    },
+  );
+  // Exactly one retry → two calls total.
+  assert.deepEqual(calls, [true, false]);
+  // invalidate() called exactly once, before the retry.
+  assert.equal(invalidated, 1);
+  assert.deepEqual(result, { success: true });
+});
+
+test("withAuthRetry: does not loop — if retry also auth-fails, still returns after 2 calls", async () => {
+  const calls: boolean[] = [];
+  let invalidated = 0;
+  const result = await withAuthRetry(
+    async (allowAuthRetry) => {
+      calls.push(allowAuthRetry);
+      return { authErrored: true, success: false };
+    },
+    () => {
+      invalidated++;
+    },
+  );
+  // First call gets authErrored: true (because allowAuthRetry=true). Second
+  // call's runner will also report authErrored=true here BUT it's ignored
+  // — we stop after one retry regardless.
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0], true);
+  assert.equal(calls[1], false);
+  assert.equal(invalidated, 1);
+  // Shape is what the second run returned (orchestration is agnostic).
+  assert.equal(result.authErrored, true);
+});

--- a/src/server/auth-retry.ts
+++ b/src/server/auth-retry.ts
@@ -1,0 +1,47 @@
+/**
+ * Auth retry helpers — shared by streaming and non-streaming chat handlers.
+ *
+ * Extracted into its own module so unit tests can import the helpers
+ * without pulling in the full routes.ts graph (subprocess pool, session
+ * manager, SQLite store) and its module-level `setInterval`s.
+ */
+import type { ClaudeProxyError } from "../claude-cli.inspect.js";
+
+/**
+ * True when an upstream Claude CLI failure looks like a revoked / expired
+ * OAuth token. Matches the ClaudeProxyError code AND does a belt-and-braces
+ * substring check on the raw message (Anthropic returns a very specific
+ * string when a token has been invalidated server-side).
+ */
+export function isAuthError(error: ClaudeProxyError): boolean {
+  if (error.code === "auth_required") return true;
+  const msg = error.message || "";
+  if (error.status === 401) return true;
+  if (/Invalid authentication credentials/i.test(msg)) return true;
+  if (/status:\s*401/i.test(msg)) return true;
+  return false;
+}
+
+export interface AuthRetryShape {
+  authErrored?: boolean;
+  success?: boolean;
+  cancelled?: boolean;
+}
+
+/**
+ * Run `run(allowAuthRetry=true)` once. If the result reports an upstream
+ * auth failure, invoke `onAuthFailure` (to invalidate caches) and re-run
+ * exactly once with `allowAuthRetry=false`. Pure orchestration — the caller
+ * owns the actual subprocess invocation and response-write side effects.
+ *
+ * Fires at most one retry per invocation. Does NOT loop.
+ */
+export async function withAuthRetry<R extends AuthRetryShape>(
+  run: (allowAuthRetry: boolean) => Promise<R>,
+  onAuthFailure: () => void,
+): Promise<R> {
+  const first = await run(true);
+  if (!first.authErrored) return first;
+  onAuthFailure();
+  return run(false);
+}

--- a/src/server/auth-retry.ts
+++ b/src/server/auth-retry.ts
@@ -6,6 +6,7 @@
  * manager, SQLite store) and its module-level `setInterval`s.
  */
 import type { ClaudeProxyError } from "../claude-cli.inspect.js";
+import { log } from "../logger.js";
 
 /**
  * True when an upstream Claude CLI failure looks like a revoked / expired
@@ -39,9 +40,31 @@ export interface AuthRetryShape {
 export async function withAuthRetry<R extends AuthRetryShape>(
   run: (allowAuthRetry: boolean) => Promise<R>,
   onAuthFailure: () => void,
+  context: { requestId?: string; conversationId?: string } = {},
 ): Promise<R> {
   const first = await run(true);
   if (!first.authErrored) return first;
+  log("auth.failure", {
+    requestId: context.requestId,
+    conversationId: context.conversationId,
+    phase: "initial",
+    message: "upstream 401 / invalid credentials; retrying once",
+  });
   onAuthFailure();
-  return run(false);
+  const second = await run(false);
+  if (second.authErrored) {
+    log("auth.failure", {
+      requestId: context.requestId,
+      conversationId: context.conversationId,
+      phase: "retry_exhausted",
+      message:
+        "upstream 401 persisted after cache invalidation — credentials likely zombie",
+    });
+  } else if (second.success) {
+    log("auth.recovered", {
+      requestId: context.requestId,
+      conversationId: context.conversationId,
+    });
+  }
+  return second;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,10 @@ import {
   handleSetThinkingBudget,
 } from "./routes.js";
 import { runtimeConfig } from "../config.js";
+import {
+  startProactiveRefresh,
+  stopProactiveRefresh,
+} from "../auth/proactive-refresh.js";
 import "../subprocess/pool.js";
 import "../store/conversation.js";
 
@@ -119,6 +123,13 @@ export async function startServer(config: ServerConfig): Promise<Server> {
       console.log(
         `[Server] OpenAI-compatible endpoint: http://${host}:${port}/v1/chat/completions`,
       );
+      // Defense-in-depth against refresh_token rotation races: proactively
+      // drive a token refresh when the access_token is approaching expiry
+      // during an otherwise-quiet interval. Only started from startServer
+      // so unit tests (which never call startServer) don't kick this off.
+      if (process.env.NODE_ENV !== "test") {
+        startProactiveRefresh();
+      }
       resolve(serverInstance!);
     });
   });
@@ -127,6 +138,7 @@ export async function startServer(config: ServerConfig): Promise<Server> {
 export async function stopServer(): Promise<void> {
   if (!serverInstance) return;
   return new Promise<void>((resolve, reject) => {
+    stopProactiveRefresh();
     serverInstance!.close((err) => {
       if (err) {
         reject(err);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -921,6 +921,14 @@ function runStreamingSubprocess(opts: StreamOpts): Promise<{
         lastAssistantError,
       );
       if (cliError) {
+        log("cli.error", {
+          requestId,
+          conversationId: cliInput._conversationId,
+          classifiedStatus: cliError.status,
+          classifiedCode: cliError.code,
+          rawResult: (result?.result || "").slice(0, 500),
+          assistantError: lastAssistantError,
+        });
         log("request.error", {
           requestId,
           conversationId: cliInput._conversationId,
@@ -1327,6 +1335,14 @@ async function runNonStreamingSubprocess(
           lastAssistantError,
         );
         if (cliError) {
+          log("cli.error", {
+            requestId,
+            conversationId: cliInput._conversationId,
+            classifiedStatus: cliError.status,
+            classifiedCode: cliError.code,
+            rawResult: (finalResult?.result || "").slice(0, 500),
+            assistantError: lastAssistantError,
+          });
           log("request.error", {
             requestId,
             conversationId: cliInput._conversationId,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1157,6 +1157,7 @@ async function handleStreamingResponse(
       });
       modelAvailability.invalidate();
     },
+    { requestId, conversationId: cliInput._conversationId },
   );
 
   if (result.success || result.cancelled) return;
@@ -1224,6 +1225,7 @@ async function handleNonStreamingResponse(
       });
       modelAvailability.invalidate();
     },
+    { requestId, conversationId: cliInput._conversationId },
   );
 }
 
@@ -1529,10 +1531,27 @@ export async function handleHealth(
   // Session failure stats
   const failureStats = sessionManager.getFailureStats();
 
+  // Auth circuit breaker: after AUTH_UNHEALTHY_THRESHOLD consecutive
+  // verifyAuth failures, respond 503 so container orchestrators (Docker
+  // healthcheck, k8s liveness) can restart the proxy instead of requiring
+  // a manual `make restart`. Once verifyAuth succeeds again, the counter
+  // resets and /health returns 200.
+  const AUTH_UNHEALTHY_THRESHOLD = 3;
+  const consecutiveAuthFailures =
+    modelAvailability.getConsecutiveAuthFailures();
+  const authUnhealthy = consecutiveAuthFailures >= AUTH_UNHEALTHY_THRESHOLD;
+  if (authUnhealthy) {
+    res.status(503);
+  }
+
   res.json({
-    status: "ok",
+    status: authUnhealthy ? "unhealthy" : "ok",
+    unhealthyReason: authUnhealthy
+      ? `verifyAuth failed ${consecutiveAuthFailures} consecutive times`
+      : undefined,
     provider: "claude-code-cli",
     timestamp: new Date().toISOString(),
+    consecutiveAuthFailures,
     sessions: {
       active: sessionManager.size,
       failureStats,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -45,6 +45,8 @@ import type {
   ClaudeCliStreamEvent,
 } from "../types/claude-cli.js";
 import { runtimeConfig, persistRuntimeState } from "../config.js";
+import { isAuthError, withAuthRetry } from "./auth-retry.js";
+export { isAuthError, withAuthRetry } from "./auth-retry.js";
 
 // ---------------------------------------------------------------------------
 // Thinking budget resolution
@@ -680,6 +682,12 @@ interface StreamOpts {
   res: Response;
   onStall: () => void;
   registerCancel?: (cancel: (error: ClaudeProxyError) => void) => void;
+  /**
+   * When true, an upstream auth/401 failure will NOT be written to the HTTP
+   * response — the caller is responsible for retrying. Used by the single
+   * auth-retry path in handleStreamingResponse / handleNonStreamingResponse.
+   */
+  allowAuthRetry?: boolean;
 }
 
 /**
@@ -687,10 +695,14 @@ interface StreamOpts {
  * returns a promise that resolves when the subprocess completes.
  * Eliminates the duplicated event handler wiring from the old retry logic.
  */
-function runStreamingSubprocess(
-  opts: StreamOpts,
-): Promise<{ fullResponse: string; success: boolean; cancelled: boolean }> {
-  const { cliInput, requestId, res, onStall, registerCancel } = opts;
+function runStreamingSubprocess(opts: StreamOpts): Promise<{
+  fullResponse: string;
+  success: boolean;
+  cancelled: boolean;
+  authErrored?: boolean;
+}> {
+  const { cliInput, requestId, res, onStall, registerCancel, allowAuthRetry } =
+    opts;
 
   const baseTimeout = getModelTimeout(cliInput.model);
   const hardTimeout = cliInput.thinkingBudget ? baseTimeout * 3 : baseTimeout;
@@ -702,6 +714,7 @@ function runStreamingSubprocess(
     fullResponse: string;
     success: boolean;
     cancelled: boolean;
+    authErrored?: boolean;
   }>((resolve) => {
     const subprocess = new ClaudeSubprocess();
     const cleanup = new CleanupSet();
@@ -731,11 +744,15 @@ function runStreamingSubprocess(
       return `data: {"id":"${chunkId}","object":"chat.completion.chunk","created":${ts},"model":"${model}","choices":[{"index":0,"delta":{"content":${escaped}},"finish_reason":null}]}\n\n`;
     };
 
-    const finish = (success: boolean, cancelled = false): void => {
+    const finish = (
+      success: boolean,
+      cancelled = false,
+      authErrored = false,
+    ): void => {
       if (isComplete) return;
       isComplete = true;
       cleanup.runAll();
-      resolve({ fullResponse, success, cancelled });
+      resolve({ fullResponse, success, cancelled, authErrored });
     };
 
     // SSE keepalive
@@ -922,10 +939,15 @@ function runStreamingSubprocess(
           console.error("[Routes] Metric error:", e);
         }
 
-        if (!clientDisconnected && !res.writableEnded) {
+        // If this is an upstream auth/401 failure AND the caller is
+        // prepared to retry (first attempt), bubble the auth error back
+        // without writing to the stream. The caller will invalidate the
+        // model-availability cache and re-run the subprocess once.
+        const authErr = allowAuthRetry && isAuthError(cliError);
+        if (!authErr && !clientDisconnected && !res.writableEnded) {
           writeStreamingError(res, cliError);
         }
-        finish(false);
+        finish(false, false, authErr);
         return;
       }
 
@@ -1107,18 +1129,33 @@ async function handleStreamingResponse(
 ): Promise<void> {
   startStreamingResponse(res, requestId);
 
-  // First attempt
-  const result = await runStreamingSubprocess({
-    cliInput,
-    requestId,
-    res,
-    registerCancel,
-    onStall: () => {
-      if (cliInput._conversationId) {
-        sessionManager.markFailed(cliInput._conversationId);
-      }
+  // First attempt, with a single 401-driven retry wrapping it. If the CLI
+  // reports auth_required / 401, invalidate the 10-min model-availability
+  // cache and re-run exactly once. The token gate serializes the re-run so
+  // the CLI has a clean refresh path.
+  const result = await withAuthRetry(
+    (allowAuthRetry) =>
+      runStreamingSubprocess({
+        cliInput,
+        requestId,
+        res,
+        registerCancel,
+        allowAuthRetry,
+        onStall: () => {
+          if (cliInput._conversationId) {
+            sessionManager.markFailed(cliInput._conversationId);
+          }
+        },
+      }),
+    () => {
+      log("request.retry", {
+        requestId,
+        conversationId: cliInput._conversationId,
+        reason: "auth_retry",
+      });
+      modelAvailability.invalidate();
     },
-  });
+  );
 
   if (result.success || result.cancelled) return;
 
@@ -1168,10 +1205,47 @@ async function handleNonStreamingResponse(
   requestId: string,
   registerCancel?: (cancel: (error: ClaudeProxyError) => void) => void,
 ): Promise<void> {
+  await withAuthRetry(
+    (allowAuthRetry) =>
+      runNonStreamingSubprocess(
+        res,
+        cliInput,
+        requestId,
+        registerCancel,
+        allowAuthRetry,
+      ),
+    () => {
+      log("request.retry", {
+        requestId,
+        conversationId: cliInput._conversationId,
+        reason: "auth_retry",
+      });
+      modelAvailability.invalidate();
+    },
+  );
+}
+
+/**
+ * Run a single non-streaming Claude CLI subprocess and write its result to
+ * `res`. When `allowAuthRetry` is true, an upstream auth/401 failure is
+ * reported back to the caller as `{authErrored: true}` WITHOUT writing the
+ * error to the HTTP response — the caller is responsible for retrying once.
+ */
+async function runNonStreamingSubprocess(
+  res: Response,
+  cliInput: CliInput,
+  requestId: string,
+  registerCancel:
+    | ((cancel: (error: ClaudeProxyError) => void) => void)
+    | undefined,
+  allowAuthRetry: boolean,
+): Promise<{ authErrored: boolean }> {
   const baseTimeout = getModelTimeout(cliInput.model);
   const timeout = cliInput.thinkingBudget ? baseTimeout * 3 : baseTimeout;
 
-  return new Promise<void>((resolve) => {
+  return new Promise<{ authErrored: boolean }>((resolve) => {
+    let authErrored = false;
+    const done = (): void => resolve({ authErrored });
     const subprocess = new ClaudeSubprocess();
     const cleanup = new CleanupSet();
     let finalResult: ClaudeCliResult | null = null;
@@ -1191,7 +1265,7 @@ async function handleNonStreamingResponse(
       isComplete = true;
       cleanup.runAll();
       respondWithError(res, error, false, requestId);
-      resolve();
+      done();
     });
 
     const timeoutId = setTimeout(() => {
@@ -1213,7 +1287,7 @@ async function handleNonStreamingResponse(
         }
         isComplete = true;
         cleanup.runAll();
-        resolve();
+        done();
       }
     }, timeout);
     cleanup.add(() => clearTimeout(timeoutId));
@@ -1236,7 +1310,7 @@ async function handleNonStreamingResponse(
           error: { message: error.message, type: "server_error", code: null },
         });
       }
-      resolve();
+      done();
     });
 
     subprocess.on("close", (code: number | null) => {
@@ -1269,10 +1343,15 @@ async function handleNonStreamingResponse(
             sessionManager.markFailed(cliInput._conversationId);
           }
 
-          if (!res.headersSent) {
+          // 401-driven retry hand-off: when the caller still has a retry
+          // budget, flag the failure instead of writing it to the response.
+          const authErr = allowAuthRetry && isAuthError(cliError);
+          if (authErr) {
+            authErrored = true;
+          } else if (!res.headersSent) {
             sendJsonError(res, cliError);
           }
-          resolve();
+          done();
           return;
         }
 
@@ -1309,7 +1388,7 @@ async function handleNonStreamingResponse(
           },
         });
       }
-      resolve();
+      done();
     });
 
     subprocess
@@ -1327,7 +1406,7 @@ async function handleNonStreamingResponse(
             error: { message: error.message, type: "server_error", code: null },
           });
         }
-        resolve();
+        done();
       });
   });
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -53,12 +53,14 @@ export { isAuthError, withAuthRetry } from "./auth-retry.js";
 // ---------------------------------------------------------------------------
 
 // Label → token-budget mapping. Labels match Claude CLI's --effort levels
-// (low, medium, high, max). "off" disables extended thinking (no --effort flag).
+// (low, medium, high, xhigh, max). "off" disables extended thinking (no --effort flag).
+// xhigh was added with Claude Opus 4.7 as an intermediate tier between high and max.
 const REASONING_EFFORT_MAP: Record<string, number> = {
   off: 0,
   low: 5000,
   medium: 10000,
   high: 32000,
+  xhigh: 48000,
   max: 64000,
 };
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -77,7 +77,7 @@ function parseEffortOrTokens(raw: string): number | undefined {
 /**
  * Resolve thinking budget from multiple sources in priority order:
  *   1. Request body `thinking.budget_tokens` (Anthropic style — explicit)
- *   2. Request body `reasoning_effort` (OpenAI style — "off" | "low" | "medium" | "high" | "max")
+ *   2. Request body `reasoning_effort` (OpenAI style — "off" | "low" | "medium" | "high" | "xhigh" | "max")
  *   3. Request header `X-Thinking-Budget` (simple client override)
  *   4. Environment variable `DEFAULT_THINKING_BUDGET` (server default)
  *

--- a/src/subprocess/manager.test.ts
+++ b/src/subprocess/manager.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { thinkingBudgetToEffort } from "./manager.js";
+
+test("thinkingBudgetToEffort falls back to max when xhigh is unsupported", () => {
+  assert.equal(thinkingBudgetToEffort(40000, false), "max");
+});
+
+test("thinkingBudgetToEffort uses xhigh when the CLI supports it", () => {
+  assert.equal(thinkingBudgetToEffort(40000, true), "xhigh");
+});
+
+test("thinkingBudgetToEffort preserves lower effort tiers", () => {
+  assert.equal(thinkingBudgetToEffort(5000, false), "low");
+  assert.equal(thinkingBudgetToEffort(10000, false), "medium");
+  assert.equal(thinkingBudgetToEffort(32000, false), "high");
+  assert.equal(thinkingBudgetToEffort(64000, true), "max");
+});

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -25,6 +25,7 @@ import type { ClaudeModel } from "../adapter/openai-to-cli.js";
 import { log } from "../logger.js";
 import {
   getCleanClaudeEnv,
+  supportsXHighEffort,
   verifyClaude,
   verifyAuth,
 } from "../claude-cli.inspect.js";
@@ -99,10 +100,13 @@ export const subprocessRegistry = new SubprocessRegistry();
  * Thresholds chosen to line up with the REASONING_EFFORT_MAP in routes.ts:
  *   low = 5000, medium = 10000, high = 32000, xhigh = 48000, max = 64000
  */
-function thinkingBudgetToEffort(budget: number): string | undefined {
+export function thinkingBudgetToEffort(
+  budget: number,
+  xhighSupported = supportsXHighEffort(),
+): string | undefined {
   if (!Number.isFinite(budget) || budget <= 0) return undefined;
   if (budget > 48000) return "max";
-  if (budget > 32000) return "xhigh";
+  if (budget > 32000) return xhighSupported ? "xhigh" : "max";
   if (budget > 10000) return "high";
   if (budget > 5000) return "medium";
   return "low";

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -97,11 +97,12 @@ export const subprocessRegistry = new SubprocessRegistry();
  * The CLI no longer accepts a raw token count; only level names.
  *
  * Thresholds chosen to line up with the REASONING_EFFORT_MAP in routes.ts:
- *   low = 5000, medium = 10000, high = 32000, max > 32000
+ *   low = 5000, medium = 10000, high = 32000, xhigh = 48000, max = 64000
  */
 function thinkingBudgetToEffort(budget: number): string | undefined {
   if (!Number.isFinite(budget) || budget <= 0) return undefined;
-  if (budget > 32000) return "max";
+  if (budget > 48000) return "max";
+  if (budget > 32000) return "xhigh";
   if (budget > 10000) return "high";
   if (budget > 5000) return "medium";
   return "low";

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -28,6 +28,7 @@ import {
   verifyClaude,
   verifyAuth,
 } from "../claude-cli.inspect.js";
+import { tokenGate } from "../auth/token-gate.js";
 
 const KILL_ESCALATION_MS = 5000;
 
@@ -115,76 +116,106 @@ export class ClaudeSubprocess extends EventEmitter {
   /**
    * Start the Claude CLI subprocess with the given prompt.
    * No timeout is set here — caller owns timeout behavior (Phase 1c).
+   *
+   * Token-gate semantics: spawns are serialized by `tokenGate` when the OAuth
+   * refresh window is active. The gate MUST hold the mutex until this
+   * subprocess has fully exited (close event) — otherwise two processes could
+   * each trigger a refresh and race on refresh_token rotation. We achieve
+   * that by having the gated fn's promise only resolve from the `close`
+   * handler. The caller's `start()` promise, by contrast, resolves as soon
+   * as the subprocess has been spawned so listeners keep working normally.
    */
   async start(prompt: string, options: SubprocessOptions): Promise<void> {
     const { args, prompt: finalPrompt } = this.buildArgs(prompt, options);
 
-    return new Promise<void>((resolve, reject) => {
-      try {
-        this.process = spawn("claude", args, {
-          cwd: options.cwd || process.cwd(),
-          env: getCleanClaudeEnv(),
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+    return new Promise<void>((startResolve, startReject) => {
+      // The promise returned here is what runGated will await: resolved only
+      // on child close (or on spawn error). That keeps the mutex held for
+      // the full subprocess lifetime.
+      const gated = tokenGate.runGated<void>(
+        () =>
+          new Promise<void>((lifecycleResolve) => {
+            try {
+              this.process = spawn("claude", args, {
+                cwd: options.cwd || process.cwd(),
+                env: getCleanClaudeEnv(),
+                stdio: ["pipe", "pipe", "pipe"],
+              });
 
-        this.process.on("error", (err: NodeJS.ErrnoException) => {
-          if (err.code === "ENOENT") {
-            reject(
-              new Error(
-                "Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code",
-              ),
-            );
-          } else {
-            reject(err);
-          }
-        });
+              this.process.on("error", (err: NodeJS.ErrnoException) => {
+                const mapped =
+                  err.code === "ENOENT"
+                    ? new Error(
+                        "Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code",
+                      )
+                    : err;
+                startReject(mapped);
+                // Release the gate so queued spawns don't stall forever when
+                // the binary is missing or spawn failed.
+                lifecycleResolve();
+              });
 
-        // Pipe the prompt through stdin. Passing large prompts as argv
-        // (OpenClaw system prompts + history) hits the kernel's ARG_MAX
-        // limit and spawn() fails with E2BIG.
-        this.process.stdin?.write(finalPrompt);
-        this.process.stdin?.end();
+              // Pipe the prompt through stdin. Passing large prompts as argv
+              // (OpenClaw system prompts + history) hits the kernel's ARG_MAX
+              // limit and spawn() fails with E2BIG.
+              this.process.stdin?.write(finalPrompt);
+              this.process.stdin?.end();
 
-        const pid = this.process.pid;
-        const effort = options.thinkingBudget
-          ? thinkingBudgetToEffort(options.thinkingBudget)
-          : undefined;
-        log("subprocess.spawn", {
-          pid,
-          model: options.model,
-          thinking: effort ?? "off",
-          thinkingTokens: options.thinkingBudget ?? 0,
-          sessionId: options.sessionId?.slice(0, 8),
-          resume: options.isResume,
-        });
+              const pid = this.process.pid;
+              const effort = options.thinkingBudget
+                ? thinkingBudgetToEffort(options.thinkingBudget)
+                : undefined;
+              log("subprocess.spawn", {
+                pid,
+                model: options.model,
+                thinking: effort ?? "off",
+                thinkingTokens: options.thinkingBudget ?? 0,
+                sessionId: options.sessionId?.slice(0, 8),
+                resume: options.isResume,
+              });
 
-        subprocessRegistry.register(this);
+              subprocessRegistry.register(this);
 
-        this.process.stdout?.on("data", (chunk: Buffer) => {
-          this.buffer += chunk.toString();
-          this.processBuffer();
-        });
+              this.process.stdout?.on("data", (chunk: Buffer) => {
+                this.buffer += chunk.toString();
+                this.processBuffer();
+              });
 
-        this.process.stderr?.on("data", (chunk: Buffer) => {
-          const errorText = chunk.toString().trim();
-          if (errorText && process.env.DEBUG) {
-            console.error("[Subprocess stderr]:", errorText.slice(0, 200));
-          }
-        });
+              this.process.stderr?.on("data", (chunk: Buffer) => {
+                const errorText = chunk.toString().trim();
+                if (errorText && process.env.DEBUG) {
+                  console.error(
+                    "[Subprocess stderr]:",
+                    errorText.slice(0, 200),
+                  );
+                }
+              });
 
-        this.process.on("close", (code: number | null) => {
-          log("subprocess.close", { pid: this.process?.pid, code });
-          subprocessRegistry.unregister(this);
-          if (this.buffer.trim()) {
-            this.processBuffer();
-          }
-          this.emit("close", code);
-        });
+              this.process.on("close", (code: number | null) => {
+                log("subprocess.close", { pid: this.process?.pid, code });
+                subprocessRegistry.unregister(this);
+                if (this.buffer.trim()) {
+                  this.processBuffer();
+                }
+                this.emit("close", code);
+                // Release the token gate only after the child has exited,
+                // guaranteeing no other gated spawn starts while this one
+                // might still be driving a refresh.
+                lifecycleResolve();
+              });
 
-        resolve();
-      } catch (err) {
-        reject(err);
-      }
+              startResolve();
+            } catch (err) {
+              startReject(err as Error);
+              lifecycleResolve();
+            }
+          }),
+      );
+      // Surface any unexpected gate-path errors (should not happen — the
+      // lifecycle promise never rejects) so they don't become unhandled.
+      gated.catch(() => {
+        /* noop: rejection path already delivered via startReject */
+      });
     });
   }
 

--- a/src/subprocess/pool.ts
+++ b/src/subprocess/pool.ts
@@ -7,9 +7,13 @@ import { spawn } from "child_process";
 import { getCleanClaudeEnv } from "../claude-cli.inspect.js";
 import { tokenGate } from "../auth/token-gate.js";
 import { log, logError } from "../logger.js";
+import { createEscalatedStop } from "./stop-with-escalation.js";
 
 const POOL_SIZE = 5;
 const WARMUP_INTERVAL_MS = 30 * 1000;
+const WARM_DEEP_TIMEOUT_MS = 10_000;
+const WARM_DEEP_KILL_GRACE_MS = 5_000;
+const WARM_DEEP_FORCE_RELEASE_MS = 1_000;
 // Only log warm success when the duration spikes past this threshold. The
 // per-cycle happy-path success fires every 30s and has zero diagnostic
 // value — it buried structured events in `docker logs`.
@@ -89,31 +93,23 @@ class SubprocessPool {
               ],
               { stdio: "pipe", env: getCleanClaudeEnv() },
             );
-            let done = false;
-            const finish = (): void => {
-              if (done) return;
-              done = true;
-              try {
-                proc.kill();
-              } catch {
-                /* ignore */
-              }
-              // proc.kill() does not guarantee immediate exit — wait for the
-              // real close event before releasing the gate.
-            };
-            // Only release the gate on actual process exit/error so the
-            // mutex is held for the full lifetime of this refresh-capable
-            // spawn.
-            proc.on("close", () => {
-              done = true;
-              resolve();
+            const stopper = createEscalatedStop(
+              proc,
+              resolve,
+              WARM_DEEP_KILL_GRACE_MS,
+              WARM_DEEP_FORCE_RELEASE_MS,
+            );
+            const timeoutId = setTimeout(
+              stopper.requestStop,
+              WARM_DEEP_TIMEOUT_MS,
+            );
+            const clearTimeouts = (): void => clearTimeout(timeoutId);
+            proc.once("close", clearTimeouts);
+            proc.once("error", () => {
+              clearTimeouts();
+              stopper.settle();
             });
-            proc.on("error", () => {
-              done = true;
-              resolve();
-            });
-            proc.stdout?.on("data", finish);
-            setTimeout(finish, 10000);
+            proc.stdout?.on("data", stopper.requestStop);
           } catch {
             resolve();
           }

--- a/src/subprocess/pool.ts
+++ b/src/subprocess/pool.ts
@@ -6,9 +6,14 @@
 import { spawn } from "child_process";
 import { getCleanClaudeEnv } from "../claude-cli.inspect.js";
 import { tokenGate } from "../auth/token-gate.js";
+import { log, logError } from "../logger.js";
 
 const POOL_SIZE = 5;
 const WARMUP_INTERVAL_MS = 30 * 1000;
+// Only log warm success when the duration spikes past this threshold. The
+// per-cycle happy-path success fires every 30s and has zero diagnostic
+// value — it buried structured events in `docker logs`.
+const WARM_SLOW_THRESHOLD_MS = 2000;
 
 class SubprocessPool {
   private warmedAt = 0;
@@ -29,11 +34,16 @@ class SubprocessPool {
         await this.warmDeep();
       }
       this.warmedAt = Date.now();
-      console.log(
-        `[SubprocessPool] Warmed ${POOL_SIZE} processes${isInitial ? " + deep warm" : ""} in ${Date.now() - start}ms`,
-      );
+      const durationMs = Date.now() - start;
+      if (isInitial || durationMs >= WARM_SLOW_THRESHOLD_MS) {
+        log("pool.warmed", {
+          poolSize: POOL_SIZE,
+          deepWarm: isInitial,
+          durationMs,
+        });
+      }
     } catch (err) {
-      console.error("[SubprocessPool] Warm error:", err);
+      logError("pool.warm_failed", err, { poolSize: POOL_SIZE });
     } finally {
       this.warming = false;
     }
@@ -134,12 +144,12 @@ export const subprocessPool = new SubprocessPool();
 
 subprocessPool
   .warm()
-  .catch((err) => console.error("[SubprocessPool] Initial warm error:", err));
+  .catch((err) => logError("pool.warm_failed", err, { phase: "initial" }));
 
 setInterval(() => {
   if (!subprocessPool.isWarm()) {
     subprocessPool
       .warm()
-      .catch((err) => console.error("[SubprocessPool] Re-warm error:", err));
+      .catch((err) => logError("pool.warm_failed", err, { phase: "interval" }));
   }
 }, WARMUP_INTERVAL_MS);

--- a/src/subprocess/pool.ts
+++ b/src/subprocess/pool.ts
@@ -5,6 +5,7 @@
  */
 import { spawn } from "child_process";
 import { getCleanClaudeEnv } from "../claude-cli.inspect.js";
+import { tokenGate } from "../auth/token-gate.js";
 
 const POOL_SIZE = 5;
 const WARMUP_INTERVAL_MS = 30 * 1000;
@@ -28,7 +29,9 @@ class SubprocessPool {
         await this.warmDeep();
       }
       this.warmedAt = Date.now();
-      console.log(`[SubprocessPool] Warmed ${POOL_SIZE} processes${isInitial ? " + deep warm" : ""} in ${Date.now() - start}ms`);
+      console.log(
+        `[SubprocessPool] Warmed ${POOL_SIZE} processes${isInitial ? " + deep warm" : ""} in ${Date.now() - start}ms`,
+      );
     } catch (err) {
       console.error("[SubprocessPool] Warm error:", err);
     } finally {
@@ -38,46 +41,86 @@ class SubprocessPool {
 
   private spawnQuick(): Promise<void> {
     return new Promise<void>((resolve) => {
-      const proc = spawn("claude", ["--version"], { stdio: "pipe", env: getCleanClaudeEnv() });
+      const proc = spawn("claude", ["--version"], {
+        stdio: "pipe",
+        env: getCleanClaudeEnv(),
+      });
       proc.on("close", () => resolve());
       proc.on("error", () => resolve());
       setTimeout(() => {
-        try { proc.kill(); } catch { /* ignore */ }
+        try {
+          proc.kill();
+        } catch {
+          /* ignore */
+        }
         resolve();
       }, 5000);
     });
   }
 
   private warmDeep(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      try {
-        const proc = spawn("claude", [
-          "--print", "--output-format", "stream-json",
-          "--model", "haiku",
-          "hi",
-        ], { stdio: "pipe", env: getCleanClaudeEnv() });
-        let done = false;
-        const finish = (): void => {
-          if (done) return;
-          done = true;
-          try { proc.kill(); } catch { /* ignore */ }
-          resolve();
-        };
-        proc.stdout?.on("data", finish);
-        proc.on("close", finish);
-        proc.on("error", finish);
-        setTimeout(finish, 10000);
-      } catch {
-        resolve();
-      }
-    });
+    // warmDeep is auth-touching (spawns `claude --print ...`) so route it
+    // through the token gate. Outside the refresh window this is a no-op;
+    // inside the window it serializes with request-path spawns so only one
+    // subprocess can drive the refresh_token rotation at a time.
+    return tokenGate.runGated<void>(
+      () =>
+        new Promise<void>((resolve) => {
+          try {
+            const proc = spawn(
+              "claude",
+              [
+                "--print",
+                "--output-format",
+                "stream-json",
+                "--model",
+                "haiku",
+                "hi",
+              ],
+              { stdio: "pipe", env: getCleanClaudeEnv() },
+            );
+            let done = false;
+            const finish = (): void => {
+              if (done) return;
+              done = true;
+              try {
+                proc.kill();
+              } catch {
+                /* ignore */
+              }
+              // proc.kill() does not guarantee immediate exit — wait for the
+              // real close event before releasing the gate.
+            };
+            // Only release the gate on actual process exit/error so the
+            // mutex is held for the full lifetime of this refresh-capable
+            // spawn.
+            proc.on("close", () => {
+              done = true;
+              resolve();
+            });
+            proc.on("error", () => {
+              done = true;
+              resolve();
+            });
+            proc.stdout?.on("data", finish);
+            setTimeout(finish, 10000);
+          } catch {
+            resolve();
+          }
+        }),
+    );
   }
 
   isWarm(): boolean {
-    return (Date.now() - this.warmedAt) < WARMUP_INTERVAL_MS;
+    return Date.now() - this.warmedAt < WARMUP_INTERVAL_MS;
   }
 
-  getStatus(): { warmedAt: string | null; isWarm: boolean; poolSize: number; warming: boolean } {
+  getStatus(): {
+    warmedAt: string | null;
+    isWarm: boolean;
+    poolSize: number;
+    warming: boolean;
+  } {
     return {
       warmedAt: this.warmedAt ? new Date(this.warmedAt).toISOString() : null,
       isWarm: this.isWarm(),
@@ -89,10 +132,14 @@ class SubprocessPool {
 
 export const subprocessPool = new SubprocessPool();
 
-subprocessPool.warm().catch(err => console.error("[SubprocessPool] Initial warm error:", err));
+subprocessPool
+  .warm()
+  .catch((err) => console.error("[SubprocessPool] Initial warm error:", err));
 
 setInterval(() => {
   if (!subprocessPool.isWarm()) {
-    subprocessPool.warm().catch(err => console.error("[SubprocessPool] Re-warm error:", err));
+    subprocessPool
+      .warm()
+      .catch((err) => console.error("[SubprocessPool] Re-warm error:", err));
   }
 }, WARMUP_INTERVAL_MS);

--- a/src/subprocess/stop-with-escalation.test.ts
+++ b/src/subprocess/stop-with-escalation.test.ts
@@ -43,3 +43,19 @@ test("createEscalatedStop settles once when the process closes after SIGTERM", a
   assert.deepEqual(proc.kills, ["SIGTERM"]);
   assert.equal(settled, 1);
 });
+
+test("createEscalatedStop settle is idempotent after an explicit error path", async () => {
+  const proc = new FakeProcess();
+  let settled = 0;
+  const stopper = createEscalatedStop(proc, () => {
+    settled++;
+  }, 20, 20);
+
+  stopper.settle();
+  stopper.settle();
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(settled, 1);
+  assert.deepEqual(proc.kills, []);
+});

--- a/src/subprocess/stop-with-escalation.test.ts
+++ b/src/subprocess/stop-with-escalation.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createEscalatedStop } from "./stop-with-escalation.js";
+
+class FakeProcess extends EventEmitter {
+  exitCode: number | null = null;
+  readonly kills: Array<string | number | undefined> = [];
+
+  kill(signal?: number | NodeJS.Signals): boolean {
+    this.kills.push(signal);
+    return true;
+  }
+}
+
+test("createEscalatedStop escalates to SIGKILL and force releases if close never arrives", async () => {
+  const proc = new FakeProcess();
+  let settled = 0;
+  const stopper = createEscalatedStop(proc, () => {
+    settled++;
+  }, 10, 5);
+
+  stopper.requestStop();
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  assert.deepEqual(proc.kills, ["SIGTERM", "SIGKILL"]);
+  assert.equal(settled, 1);
+});
+
+test("createEscalatedStop settles once when the process closes after SIGTERM", async () => {
+  const proc = new FakeProcess();
+  let settled = 0;
+  const stopper = createEscalatedStop(proc, () => {
+    settled++;
+  }, 20, 20);
+
+  stopper.requestStop();
+  proc.exitCode = 0;
+  proc.emit("close", 0);
+
+  await new Promise((resolve) => setTimeout(resolve, 40));
+
+  assert.deepEqual(proc.kills, ["SIGTERM"]);
+  assert.equal(settled, 1);
+});

--- a/src/subprocess/stop-with-escalation.ts
+++ b/src/subprocess/stop-with-escalation.ts
@@ -1,0 +1,64 @@
+export interface EscalatedStopHandle {
+  requestStop: () => void;
+  settle: () => void;
+}
+
+interface StoppableProcess {
+  exitCode: number | null;
+  kill(signal?: number | NodeJS.Signals): boolean;
+  once(event: "close", listener: () => void): this;
+}
+
+/**
+ * Request a polite stop first, escalate to SIGKILL after `killGraceMs`,
+ * and release the caller even if the runtime never delivers `close`.
+ */
+export function createEscalatedStop(
+  proc: StoppableProcess,
+  onSettled: () => void,
+  killGraceMs = 5000,
+  forceReleaseMs = 1000,
+): EscalatedStopHandle {
+  let stopRequested = false;
+  let settled = false;
+  let escalationTimer: ReturnType<typeof setTimeout> | null = null;
+  let forceReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const settle = (): void => {
+    if (settled) return;
+    settled = true;
+    if (escalationTimer) clearTimeout(escalationTimer);
+    if (forceReleaseTimer) clearTimeout(forceReleaseTimer);
+    onSettled();
+  };
+
+  proc.once("close", settle);
+
+  return {
+    requestStop(): void {
+      if (stopRequested) return;
+      stopRequested = true;
+
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        settle();
+        return;
+      }
+
+      escalationTimer = setTimeout(() => {
+        if (proc.exitCode === null) {
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            /* ignore */
+          }
+          forceReleaseTimer = setTimeout(settle, forceReleaseMs);
+          return;
+        }
+        settle();
+      }, killGraceMs);
+    },
+    settle,
+  };
+}


### PR DESCRIPTION
## Problem

After ~24h of uptime, the proxy returns `HTTP 503` wrapping `401 authentication_error` from Anthropic. `.credentials.json` has a fresh `expiresAt` and `claude auth status` reports `loggedIn: true`; Anthropic rejects every call. A container restart clears it.

Root cause: the Claude CLI rotates the `refresh_token` on each refresh. Concurrent `claude` spawns (request handler, pool deep-warm, model probes) race on the same `refresh_token`. The first POST wins; the others POST an invalidated token and their response overwrites `.credentials.json` with stale data. Disk looks valid, the server has revoked it.

## Fix

1. **Token gate** (`src/auth/token-gate.ts`) — promise-chain mutex serializes spawns inside `[expiresAt - 10min, expiresAt + 2min]`. Outside the window: fast path. Mutex held for the full subprocess lifetime so streams cannot race mid-request.
2. **401 auto-recovery** (`src/server/auth-retry.ts`, `routes.ts`) — on upstream auth error, invalidate the 10-min probe cache and retry once. `ModelAvailabilityManager` self-heals at most once per 60s when the snapshot shows unauthenticated.
3. **Proactive refresh** (`src/auth/proactive-refresh.ts`) — 6h interval fires one gated `claude --print` when `expiresAt - now < 2h`.

Gated call sites: `runClaudeCommand`, `ClaudeSubprocess.start`, pool `warmDeep`. `--version` warm-ups skip the gate.

## Verification

- `tsc` clean, `npm test` 28/28 pass (new tests cover gate serialization, auth-error classification, retry-once semantics).
- Container rebuilt and redeployed; `/health` reports 5 models available and `loggedIn: true`.

## Scope

No new deps. No compose or bind-mount changes. No in-image CLI version bump.

## Caveat

Host `claude` invocations sit outside the proxy's mutex. A host refresh at the same second as a container spawn can still race; the 401-retry path recovers within one request.

## Test plan

- [ ] `npm ci && npm run build && npm test`
- [ ] `docker compose build --no-cache claude-max-proxy`
- [ ] `/health` shows `loggedIn: true` and populated `models.available` at boot
- [ ] 48h soak: no `auth_required` errors in logs
