### PR TITLE
docs(troubleshooting): document client-side streaming watchdogs

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -140,6 +140,22 @@ Watch for `subprocess.stall` and `subprocess.kill` events in the log. If you're 
 
 Intentional. When the HTTP client closes the SSE connection, the proxy immediately kills the underlying subprocess so the conversation queue can unblock. If you want the request to finish even after disconnect, don't close the stream.
 
+### Client fires its own "no stream activity" watchdog during long Claude thinking
+
+Some OpenAI-compatible clients (notably the OpenClaw TUI, which uses a 30 s `streamingWatchdogMs` by default) run their own per-request watchdog that fires if they haven't seen a content chunk in N seconds. When Claude legitimately goes quiet during deep reasoning or tool execution, these client watchdogs trip and surface a misleading "the backend dropped this run silently" message even though the proxy is still happily streaming.
+
+This is a client-side false positive, not a proxy failure. The proxy's activity-based stall detection (Haiku 45 s / Sonnet 90 s / Opus 120 s, above) is the authoritative source of truth: if the run has actually stalled, the proxy kills the subprocess and sends a `finish_reason` that cleanly ends the stream for the client.
+
+Why the proxy can't paper over this itself:
+
+- SSE comment keepalives (`:keepalive\n\n`) are stripped by spec-compliant SSE parsers before the chunk ever reaches the client's event handler.
+- OpenAI-format "empty" chunks (`delta: {}` or `delta: { content: "" }`) are dropped by virtually every OpenAI stream consumer — they require a non-empty `content`, `reasoning_content`, or `tool_calls` field to dispatch an event. Emitting visible-content heartbeats would pollute the assistant message.
+
+**Fix, in order of preference:**
+
+1. Raise or disable the client's watchdog. For OpenClaw: there is currently no config knob for `streamingWatchdogMs`, so you have to patch `DEFAULT_STREAMING_WATCHDOG_MS` in the installed `dist/tui-*.js` bundle (30 s → 10 min is a reasonable default since the proxy's own stall detection supersedes it).
+2. If the client exposes a config knob, set it to something well above the proxy's hard timeouts (Haiku 2 min / Sonnet 10 min / Opus 30 min).
+
 ---
 
 ## Same-conversation weirdness
@@ -187,15 +203,15 @@ lsof -iTCP:3456 -sTCP:LISTEN
 
 The proxy emits one JSON object per line to stdout. To filter for a specific event:
 
+The following examples assume you're running under `launchd` on macOS with the LaunchAgent from [macos-setup.md](./macos-setup.md), which writes logs to `~/Library/Logs/claude-max-api-proxy.log` (and `.err.log`). If you're running in the foreground (`npm start`), substitute stdout/stderr for the tail commands.
+
 ```bash
 # Every request completion
-tail -f /tmp/claude-max-api-proxy.log | grep '"event":"request.complete"'
+tail -f "$HOME/Library/Logs/claude-max-api-proxy.log" | grep '"event":"request.complete"'
 
 # Every stall
-tail -f /tmp/claude-max-api-proxy.log | grep '"event":"subprocess.stall"'
+tail -f "$HOME/Library/Logs/claude-max-api-proxy.log" | grep '"event":"subprocess.stall"'
 
 # Everything for one conversation
-tail -f /tmp/claude-max-api-proxy.log | grep '"conversationId":"chat-abc-123"'
+tail -f "$HOME/Library/Logs/claude-max-api-proxy.log" | grep '"conversationId":"chat-abc-123"'
 ```
-
-If you're running under `launchd` on macOS, logs go to `/tmp/claude-max-api-proxy.log` and `/tmp/claude-max-api-proxy.err.log` per the LaunchAgent config in [macos-setup.md](./macos-setup.md).


### PR DESCRIPTION
## Summary

- Adds a new Troubleshooting entry documenting a false-positive failure mode that comes from the *client* side, not the proxy: OpenAI-compatible clients (most prominently the OpenClaw TUI, via its 30 s `streamingWatchdogMs`) that run their own per-request "no content chunk for N seconds" watchdogs alongside SSE streaming. When Claude legitimately goes silent during deep reasoning or a long tool call, those watchdogs fire and surface a misleading "the backend dropped this run silently" message even though the proxy is still streaming normally.
- Explains why we can't paper over it from inside the proxy (SSE comment keepalives are spec-stripped; empty OpenAI delta chunks are filtered by virtually every consumer; content heartbeats would pollute the assistant message), so the remediation has to happen on the client.
- Points users at concrete fixes (raise or disable the client watchdog; for OpenClaw, patch `DEFAULT_STREAMING_WATCHDOG_MS` in the compiled TUI bundle since there's no config knob today).
- Reaffirms that the proxy's own activity-based stall detection (Haiku 45 s / Sonnet 90 s / Opus 120 s, plus family hard timeouts) is the authoritative source of truth for dropped runs.
- Corrects stale `/tmp/claude-max-api-proxy.log` references in the "Log diving" section that were orphaned when v1.0.2 moved the macOS LaunchAgent logs to `~/Library/Logs/`. All `tail -f` examples and the surrounding prose now match the current `macos-setup.md`.

## Why this matters

This was diagnosed by tracing the SSE chain end-to-end:

- Proxy emits `:keepalive\n\n` every 5 s during idle → SSE parsers strip comments → no chunk reaches the client.
- Tried OpenAI-format heartbeat chunks with empty delta — verified against the Gateway's stream parser (`anthropic-vertex-stream-BpkPWKP9.js:6469`) and the TUI's `streamAssembler.ingestDelta` (`tui-CD9-89mO.js:2552`): both filter unless `delta.content` is truthy. Empty chunks are a dead end.
- Meanwhile the proxy's own stall detection is strictly better than any generic client watchdog, because it knows the model family and can kill precisely when activity actually stops.

Absent a client config knob, users will keep hitting this and assuming the proxy is to blame. This section gives them a single place to land when they Google the error string.

## Test plan

- [x] `docs/TROUBLESHOOTING.md` renders cleanly on GitHub (tables, code blocks, headings).
- [x] All `tail -f` examples reference `$HOME/Library/Logs/claude-max-api-proxy.log`, matching `macos-setup.md` after v1.0.2.
- [x] No changes to source; docs-only PR, no build or test impact.