### PR TITLE
fix: report the model that served the turn, not an auxiliary one

### DIFF
--- a/src/adapter/cli-to-openai.test.ts
+++ b/src/adapter/cli-to-openai.test.ts
@@ -43,3 +43,34 @@ test("cliResultToOpenai strips provider prefixes without pinning model versions"
 
   assert.equal(response.model, "claude-opus-4-7");
 });
+
+test("cliResultToOpenai reports the served model, not an auxiliary one", () => {
+  // Claude Code bills auxiliary work to a cheaper model alongside the real
+  // turn, and lists it first in modelUsage. Taking key[0] reported haiku for
+  // every request regardless of the model actually asked for.
+  const result = makeResult();
+  result.modelUsage = {
+    "claude-haiku-4-5-20251001": { inputTokens: 525, outputTokens: 12, costUSD: 0 },
+    "claude-sonnet-5": { inputTokens: 2, outputTokens: 9, costUSD: 0 },
+  };
+
+  const response = cliResultToOpenai(result, "req-aux", "sonnet");
+
+  // The auxiliary entry is both first and larger, so this only passes if the
+  // requested family actually decides the winner.
+  assert.equal(response.model, "claude-sonnet-5");
+});
+
+test("cliResultToOpenai falls back to the busiest model when the family differs", () => {
+  // --fallback-model can serve a different family than requested; report what
+  // actually ran rather than what was asked for.
+  const result = makeResult();
+  result.modelUsage = {
+    "claude-haiku-4-5-20251001": { inputTokens: 525, outputTokens: 12, costUSD: 0 },
+    "claude-sonnet-4-6": { inputTokens: 40, outputTokens: 900, costUSD: 0 },
+  };
+
+  const response = cliResultToOpenai(result, "req-fallback", "opus");
+
+  assert.equal(response.model, "claude-sonnet-4-6");
+});

--- a/src/adapter/cli-to-openai.test.ts
+++ b/src/adapter/cli-to-openai.test.ts
@@ -61,16 +61,41 @@ test("cliResultToOpenai reports the served model, not an auxiliary one", () => {
   assert.equal(response.model, "claude-sonnet-5");
 });
 
-test("cliResultToOpenai falls back to the busiest model when the family differs", () => {
-  // --fallback-model can serve a different family than requested; report what
-  // actually ran rather than what was asked for.
+test("cliResultToOpenai uses the assistant event for a cross-family fallback", () => {
+  // The auxiliary model can produce more output than the real turn, so token
+  // counts cannot reliably identify which model served the response.
   const result = makeResult();
   result.modelUsage = {
-    "claude-haiku-4-5-20251001": { inputTokens: 525, outputTokens: 12, costUSD: 0 },
-    "claude-sonnet-4-6": { inputTokens: 40, outputTokens: 900, costUSD: 0 },
+    "claude-haiku-4-5-20251001": {
+      inputTokens: 525,
+      outputTokens: 120,
+      costUSD: 0,
+    },
+    "claude-sonnet-4-6": { inputTokens: 40, outputTokens: 9, costUSD: 0 },
   };
 
-  const response = cliResultToOpenai(result, "req-fallback", "opus");
+  const response = cliResultToOpenai(
+    result,
+    "req-fallback",
+    "opus",
+    "claude-sonnet-4-6",
+  );
 
   assert.equal(response.model, "claude-sonnet-4-6");
+});
+
+test("cliResultToOpenai does not guess from usage when no model evidence exists", () => {
+  const result = makeResult();
+  result.modelUsage = {
+    "claude-haiku-4-5-20251001": {
+      inputTokens: 525,
+      outputTokens: 120,
+      costUSD: 0,
+    },
+    "claude-sonnet-4-6": { inputTokens: 40, outputTokens: 9, costUSD: 0 },
+  };
+
+  const response = cliResultToOpenai(result, "req-unknown", "opus");
+
+  assert.equal(response.model, "opus");
 });

--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -2,7 +2,7 @@
  * Converts Claude CLI output to OpenAI-compatible response format
  * Phase 5c: Token validation and streaming token estimates
  */
-import { normalizeModelName } from "../models.js";
+import { normalizeModelName, resolveModelFamily } from "../models.js";
 import type { ClaudeCliAssistant, ClaudeCliResult } from "../types/claude-cli.js";
 import type { OpenAIChatResponse, OpenAIChatChunk } from "../types/openai.js";
 
@@ -97,6 +97,43 @@ export function validateTokens(
 }
 
 /**
+ * Pick the model that actually served the turn out of the CLI's `modelUsage`.
+ *
+ * Claude Code bills auxiliary work (quota probes, title generation) to a
+ * cheaper model alongside the real turn, so `modelUsage` routinely carries two
+ * entries and object key order is not meaningful:
+ *
+ *   { "claude-haiku-4-5-...": {in:525,out:12},  <- auxiliary
+ *     "claude-fable-5":       {in:2,  out:9 } } <- the actual turn
+ *
+ * Taking the first key made every response report the auxiliary model. Prefer
+ * the entry whose family matches what the caller asked for; if the CLI fell
+ * back to a different model (`--fallback-model`) no family matches, so fall
+ * back to the entry that generated the most output — the real turn — and only
+ * then to the requested model name.
+ */
+export function selectPrimaryModel(
+  modelUsage: ClaudeCliResult["modelUsage"] | undefined,
+  requestedModel: string,
+): string {
+  const entries = Object.entries(modelUsage || {});
+  if (entries.length === 0) return requestedModel;
+  if (entries.length === 1) return entries[0][0];
+
+  const requestedFamily = resolveModelFamily(requestedModel);
+  if (requestedFamily) {
+    const match = entries.find(
+      ([name]) => resolveModelFamily(name) === requestedFamily,
+    );
+    if (match) return match[0];
+  }
+
+  return entries.reduce((best, entry) =>
+    (entry[1]?.outputTokens ?? 0) > (best[1]?.outputTokens ?? 0) ? entry : best,
+  )[0];
+}
+
+/**
  * Convert Claude CLI result to OpenAI non-streaming response
  */
 export function cliResultToOpenai(
@@ -104,7 +141,7 @@ export function cliResultToOpenai(
   requestId: string,
   fallbackModel = "sonnet",
 ): OpenAIChatResponse {
-  const modelName = Object.keys(result.modelUsage || {})[0] || fallbackModel;
+  const modelName = selectPrimaryModel(result.modelUsage, fallbackModel);
 
   return {
     id: `chatcmpl-${requestId}`,

--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -97,7 +97,7 @@ export function validateTokens(
 }
 
 /**
- * Pick the model that actually served the turn out of the CLI's `modelUsage`.
+ * Pick the model that actually served the turn.
  *
  * Claude Code bills auxiliary work (quota probes, title generation) to a
  * cheaper model alongside the real turn, so `modelUsage` routinely carries two
@@ -106,16 +106,19 @@ export function validateTokens(
  *   { "claude-haiku-4-5-...": {in:525,out:12},  <- auxiliary
  *     "claude-fable-5":       {in:2,  out:9 } } <- the actual turn
  *
- * Taking the first key made every response report the auxiliary model. Prefer
- * the entry whose family matches what the caller asked for; if the CLI fell
- * back to a different model (`--fallback-model`) no family matches, so fall
- * back to the entry that generated the most output — the real turn — and only
- * then to the requested model name.
+ * Taking the first key made every response report the auxiliary model. The
+ * assistant event is authoritative when available, including when
+ * `--fallback-model` served a different family. Older or incomplete CLI output
+ * may omit that event, so in that case prefer a usage entry from the requested
+ * family and finally fall back to the requested model name.
  */
 export function selectPrimaryModel(
   modelUsage: ClaudeCliResult["modelUsage"] | undefined,
   requestedModel: string,
+  servedModel?: string,
 ): string {
+  if (servedModel?.trim()) return servedModel;
+
   const entries = Object.entries(modelUsage || {});
   if (entries.length === 0) return requestedModel;
   if (entries.length === 1) return entries[0][0];
@@ -128,9 +131,7 @@ export function selectPrimaryModel(
     if (match) return match[0];
   }
 
-  return entries.reduce((best, entry) =>
-    (entry[1]?.outputTokens ?? 0) > (best[1]?.outputTokens ?? 0) ? entry : best,
-  )[0];
+  return requestedModel;
 }
 
 /**
@@ -140,8 +141,13 @@ export function cliResultToOpenai(
   result: ClaudeCliResult,
   requestId: string,
   fallbackModel = "sonnet",
+  servedModel?: string,
 ): OpenAIChatResponse {
-  const modelName = selectPrimaryModel(result.modelUsage, fallbackModel);
+  const modelName = selectPrimaryModel(
+    result.modelUsage,
+    fallbackModel,
+    servedModel,
+  );
 
   return {
     id: `chatcmpl-${requestId}`,

--- a/src/server/chat-execution.ts
+++ b/src/server/chat-execution.ts
@@ -697,6 +697,7 @@ async function runNonStreamingSubprocess(
     const subprocess = new ClaudeSubprocess();
     const cleanup = new CleanupSet();
     let finalResult: ClaudeCliResult | null = null;
+    let lastAssistantModel: string | undefined;
     let lastAssistantText = "";
     let lastAssistantError: string | undefined;
     let isComplete = false;
@@ -745,6 +746,7 @@ async function runNonStreamingSubprocess(
     });
 
     subprocess.on("assistant", (message: ClaudeCliAssistant) => {
+      lastAssistantModel = message.message.model;
       lastAssistantText = extractTextContent(message);
       lastAssistantError = message.error;
     });
@@ -842,7 +844,14 @@ async function runNonStreamingSubprocess(
         }
 
         if (!res.headersSent) {
-          res.json(cliResultToOpenai(finalResult, requestId, cliInput.model));
+          res.json(
+            cliResultToOpenai(
+              finalResult,
+              requestId,
+              cliInput.model,
+              lastAssistantModel,
+            ),
+          );
         }
       } else if (!res.headersSent) {
         res.status(500).json({


### PR DESCRIPTION
## Problem

Non-streaming responses could report an auxiliary Claude model from modelUsage instead of the model that served the turn. Object key order and token volume are not reliable indicators because auxiliary work can appear first and can produce more output than the final response.

## Fix

Prefer the model reported by the actual assistant event. This also reports cross-family --fallback-model execution correctly. If an older or incomplete CLI result has no assistant-model evidence, use a modelUsage entry matching the requested family; when neither source identifies the model, preserve the requested model instead of guessing from token counts.

## Validation

- Covers auxiliary-model ordering and volume.
- Covers cross-family fallback using the authoritative assistant event.
- Covers the no-evidence case to prevent heuristic misreporting.
- Full local suite: 111/111 passing.
- npm audit: 0 vulnerabilities.